### PR TITLE
Fixes Typo in NewMailMessage.php

### DIFF
--- a/src/Notifications/NewMailMessage.php
+++ b/src/Notifications/NewMailMessage.php
@@ -72,7 +72,7 @@ class NewMailMessage extends Notification
     {
 
         return (new MailMessage)
-            ->line('You have revceived a new EVEMail!')
+            ->line('You have received a new EVEMail!')
             ->line(
                 'The message is from ' . $this->message->senderName . ' with ' .
                 'subject: ' . $this->message->title . '. A snippet from the mail ' .


### PR DESCRIPTION
The Notification Email for a new EVEMail reads "You have revceived a new EVEMail!", that should be "received", i think.


(Yes, PR is utterly pointless).