### PR TITLE
Starbase Siphon alert hotfix

### DIFF
--- a/src/Alerts/Corp/StarbaseSiphons.php
+++ b/src/Alerts/Corp/StarbaseSiphons.php
@@ -70,31 +70,35 @@ class StarbaseSiphons extends Base
                     // Get the details (with module details) of a specific starbase
                     $details = $this->getCorporationStarbases($corporation_id, $starbase->itemID);
 
-                    // Loop over each module at the starbase and
-                    // check if it looks like a siphon is present on a silo.
-                    $details->modules->each(function ($module) use (
-                        $corporation_id, $starbase, &$siphon
-                    ) {
+                    // modules attributes may not exists
+                    // ensure the value is not returning null before iterating over it
+                    if ($details->modules != null) {
 
-                        if (
-                            // If we have a silo (typeID 14343)
-                            $module['detail']->typeID == 14343 &&
-
-                            // And total items is not divisble by 100
-                            $module['total_items'] % 100 > 0
+                        // Loop over each module at the starbase and
+                        // check if it looks like a siphon is present on a silo.
+                        $details->modules->each(function ($module) use (
+                            $corporation_id, $starbase, &$siphon
                         ) {
 
-                            // Push information about this module as one
-                            // that is possibly being siphoned.
-                            $siphon->push([
-                                'corporation_id' => $corporation_id,
-                                'type'           => $starbase->starbaseTypeName,
-                                'name'           => $starbase->starbaseName,
-                                'location'       => $starbase->moonName,
-                                'total_items'    => $module['total_items'],
-                            ]);
-                        }
-                    });
+                            if (
+                                // If we have a silo (typeID 14343)
+                                $module['detail']->typeID == 14343 &&
+
+                                // And total items is not divisible by 100
+                                $module['total_items'] % 100 > 0
+                            ) {
+                                // Push information about this module as one
+                                // that is possibly being siphoned.
+                                $siphon->push([
+                                    'corporation_id' => $corporation_id,
+                                    'type'           => $starbase->starbaseTypeName,
+                                    'name'           => $starbase->starbaseName,
+                                    'location'       => $starbase->moonName,
+                                    'total_items'    => $module['total_items'],
+                                ]);
+                            }
+                        });
+                    }
 
                 });
         });

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -23,7 +23,7 @@
 Route::group([
     'namespace'  => 'Seat\Notifications\Http\Controllers',
     'prefix'     => 'notifications',
-    'middleware' => 'web',
+    'middleware' => ['web', 'auth'],
 ], function () {
 
     Route::get('/', [


### PR DESCRIPTION
A starbase may be empty and therefore, don't have a modules attribute according to https://github.com/eveseat/services/blob/master/src/Repositories/Corporation/Starbases.php#L191-L194

```
[2017-05-06 18:55:09] local.ERROR: Symfony\Component\Debug\Exception\FatalThrowableError: Call to a member function each() on null in /srv/dae-i.eveseat.net/vendor/eveseat/notifications/src/Alerts/Corp/StarbaseSiphons.php:75
#0 /srv/dae-i.eveseat.net/bootstrap/cache/compiled.php(12819): Seat\Notifications\Alerts\Corp\StarbaseSiphons->Seat\Notifications\Alerts\Corp\{closure}(Object(Seat\Eveapi\Models\Corporation\Starbase), 7)
#1 /srv/dae-i.eveseat.net/vendor/eveseat/notifications/src/Alerts/Corp/StarbaseSiphons.php(99): Illuminate\Support\Collection->each(Object(Closure))
#2 /srv/dae-i.eveseat.net/bootstrap/cache/compiled.php(12819): Seat\Notifications\Alerts\Corp\StarbaseSiphons->Seat\Notifications\Alerts\Corp\{closure}(98456198, 0)
#3 /srv/dae-i.eveseat.net/vendor/eveseat/notifications/src/Alerts/Corp/StarbaseSiphons.php(100): Illuminate\Support\Collection->each(Object(Closure))
#4 /srv/dae-i.eveseat.net/vendor/eveseat/notifications/src/Alerts/Base.php(73): Seat\Notifications\Alerts\Corp\StarbaseSiphons->getData()
#5 /srv/dae-i.eveseat.net/vendor/eveseat/notifications/src/Commands/AlertsRun.php(72): Seat\Notifications\Alerts\Base->__construct()
#6 [internal function]: Seat\Notifications\Commands\AlertsRun->handle()
#12 /srv/dae-i.eveseat.net/vendor/symfony/console/Application.php(185): Symfony\Component\Console\Application->doRunCommand(Object(Seat\Notifications\Commands\AlertsRun), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
```