### PR TITLE
feat(icons): Upgrade package to handle font-awesome 5 properly

### DIFF
--- a/src/Config/package.sidebar.php
+++ b/src/Config/package.sidebar.php
@@ -25,27 +25,27 @@ return [
     'notifications' => [
         'name'          => 'notifications',
         'label'         => 'Notifications',
-        'icon'          => 'fa-hand-stop-o',
+        'icon'          => 'far fa-hand-paper',
         'route_segment' => 'notifications',
         'entries'       => [
             [
                 'name'       => 'integrations',
                 'label'      => 'Integrations',
                 'permission' => 'notifications',
-                'icon'       => 'fa-toggle-on',
+                'icon'       => 'fas fa-toggle-on',
                 'route'      => 'notifications.integrations.list',
             ],
             [
                 'name'  => 'notifications',
                 'label' => 'My Notifications',
-                'icon'  => 'fa-envelope-square',
+                'icon'  => 'fas fa-envelope-square',
                 'route' => 'notifications.list',
             ],
             [
                 'name'       => 'notification.groups',
                 'label'      => 'Notifications Groups',
                 'permission' => 'notifications',
-                'icon'       => 'fa-object-group',
+                'icon'       => 'far fa-object-group',
                 'route'      => 'notifications.groups.list',
             ],
         ],


### PR DESCRIPTION
Bump icons dependencies to FA5 which provide us lot of new icons, especially brands on.
Both AdminLTE stylesheet and blades has been updated.

Move the `fa` class to package sidebar icons value as since 5.x, there are 4 distinct styling :
 - `fas` which is mainly the previous `fa`
 - `far` which is under license except for icons renamed from FA4
 - `fal` which is under license
 - `fab` which is providing all "business" icons, like Discord brand, Slack brand, etc...

**In case blades are updated since notifications 3.0.2, double check they are properly updated by this package**