### PR TITLE
fix(notifications): enforce corporation killmails sorting

### DIFF
--- a/src/Alerts/Corp/Killmails.php
+++ b/src/Alerts/Corp/Killmails.php
@@ -60,6 +60,7 @@ class Killmails extends Base
         foreach ($this->getAllCorporations()->unique('corporation_id') as $corporation) {
 
             $this->getCorporationKillmails($corporation->corporation_id)
+                ->orderBy('killmail_id', 'asc')
                 ->each(function ($killmail) use (&$killmails) {
 
                     // Add the killmail to the collection.


### PR DESCRIPTION
due to our surrogate pattern, the each method is causing an exception
when it attempt to
sort records based on the primary key.

Closes eveseat/seat#551