### PR TITLE
fix(notifications): enforce corporation member tracking sorting

### DIFF
--- a/src/Alerts/Corp/MemberTokenState.php
+++ b/src/Alerts/Corp/MemberTokenState.php
@@ -60,6 +60,7 @@ class MemberTokenState extends Base
         foreach ($this->getAllCorporations()->unique('corporation_id') as $corporation) {
 
             $this->getCorporationMemberTracking($corporation->corporation_id)
+                ->orderBy('character_id', 'asc')
                 ->each(function ($member) use (&$members) {
 
                     // Add the member to the collection.


### PR DESCRIPTION
due to our surrogate pattern, the each method is causing an exception
when it attempt to sort records based on the primary key.

Closes eveseat/seat#552