### PR TITLE
feat(notifications): add structure under attack support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     "laravel/framework": "5.5.*",
     "eveseat/eveapi": "~3",
     "eveseat/services": "~3",
-    "yajra/laravel-datatables-oracle": "~8"
+    "yajra/laravel-datatables-oracle": "~8",
+    "ext-yaml": "*"
   },
   "extra": {
     "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
     "laravel/framework": "5.5.*",
     "eveseat/eveapi": "~3",
     "eveseat/services": "~3",
-    "yajra/laravel-datatables-oracle": "~8",
-    "ext-yaml": "*"
+    "symfony/yaml": "^3.0",
+    "yajra/laravel-datatables-oracle": "~8"
   },
   "extra": {
     "laravel": {

--- a/src/Alerts/Char/StructureUnderAttack.php
+++ b/src/Alerts/Char/StructureUnderAttack.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015, 2016, 2017, 2018, 2019  Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Notifications\Alerts\Char;
+
+use Illuminate\Support\Collection;
+use Seat\Eveapi\Models\Character\CharacterNotification;
+use Seat\Notifications\Alerts\Base;
+
+class StructureUnderAttack extends Base
+{
+
+    /**
+     * The field to use from the data when trying
+     * to infer an affiliation.
+     *
+     * @return string
+     */
+    public function getAffiliationField()
+    {
+        return 'character_id';
+    }
+
+    /**
+     * The required method to handle the Alert.
+     *
+     * @return mixed
+     */
+    protected function getData(): Collection
+    {
+        return CharacterNotification::where('timestamp', '>', carbon('now')->subWeek())
+            ->where('type', 'StructureUnderAttack')
+            ->get();
+    }
+
+    /**
+     * The name of the alert. This is also the name
+     * of the notifier to use.
+     *
+     * @return string
+     */
+    protected function getName(): string
+    {
+        return 'structureunderattack';
+    }
+
+    /**
+     * The type of notification.
+     *
+     * @return string
+     */
+    protected function getType(): string
+    {
+        return 'char';
+    }
+
+    /**
+     * Fields in a collection row that make the alert
+     * unique.
+     *
+     * @return array
+     */
+    protected function getUniqueFields(): array
+    {
+        return ['character_id', 'notification_id'];
+    }
+}

--- a/src/Alerts/Char/StructureUnderAttack.php
+++ b/src/Alerts/Char/StructureUnderAttack.php
@@ -28,7 +28,6 @@ use Seat\Notifications\Alerts\Base;
 
 class StructureUnderAttack extends Base
 {
-
     /**
      * The field to use from the data when trying
      * to infer an affiliation.

--- a/src/Config/notifications.alerts.php
+++ b/src/Config/notifications.alerts.php
@@ -35,6 +35,11 @@ return [
             'alert'    => \Seat\Notifications\Alerts\Char\NewMailMessage::class,
             'notifier' => \Seat\Notifications\Notifications\NewMailMessage::class,
         ],
+        'structureunderattack' => [
+            'name' => 'Structure Under Attack',
+            'alert' => \Seat\Notifications\Alerts\Char\StructureUnderAttack::class,
+            'notifier' => \Seat\Notifications\Notifications\StructureUnderAttack::class,
+        ],
     ],
     'corp' => [
 

--- a/src/Notifications/StructureUnderAttack.php
+++ b/src/Notifications/StructureUnderAttack.php
@@ -1,0 +1,215 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015, 2016, 2017, 2018, 2019  Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Notifications\Notifications;
+
+use Illuminate\Notifications\Messages\SlackMessage;
+use Illuminate\Notifications\Notification;
+use Seat\Eveapi\Models\Character\MailMessage;
+use Seat\Eveapi\Models\Sde\InvType;
+use Seat\Eveapi\Models\Sde\MapDenormalize;
+use Seat\Eveapi\Models\Universe\UniverseStructure;
+
+class StructureUnderAttack extends Notification
+{
+
+    /**
+     * @var \Seat\Eveapi\Models\Character\CharacterNotification
+     */
+    private $notification;
+
+    /**
+     * StructureUnderAttack constructor.
+     * @param \Seat\Eveapi\Models\Character\CharacterNotification $notification
+     */
+    public function __construct($notification)
+    {
+        $this->notification = $notification;
+    }
+
+    /**
+     * @param $notifiable
+     * @return mixed
+     */
+    public function via($notifiable)
+    {
+
+        return $notifiable->notificationChannels();
+    }
+
+    /**
+     * @param $notifiable
+     * @return mixed
+     */
+    public function toMail($notifiable)
+    {
+
+        $data = yaml_parse($this->notification->text);
+
+        $system = MapDenormalize::find($data['solarsystemID']);
+
+        return (new MailMessage)
+            ->subject('Structure Under Attack Notification')
+            ->line('A structure is under attack!')
+            ->line(
+                sprintf('Citadel (%s, "%s" attacked')
+            )
+            ->line(
+                sprintf('(%d shield, %d armor, %d hull)',
+                    $data['shieldPercentage'],
+                    $data['armorPercentage'],
+                    $data['hullPercentage'])
+            )
+            ->line(
+                sprintf('in %s by %s',
+                    $system->itemName,
+                    $data['corpName'])
+            );
+    }
+
+    /**
+     * @param $notifiable
+     * @return SlackMessage
+     */
+    public function toSlack($notifiable)
+    {
+
+        $data = yaml_parse($this->notification->text);
+
+        return (new SlackMessage)
+            ->content('A structure is under attack!')
+            ->from('SeAT StructureUnderAttack')
+            ->attachment(function ($attachment) use ($data) {
+                $attachment->field(function ($field) use ($data) {
+                    $field->title('Attacker')
+                        ->content(
+                            $this->zKillBoardToSlackLink(
+                                'corporation',
+                                $data['corpLinkData'][2],
+                                $data['corpName']
+                            ));
+                    })
+                    ->field(function ($field) use ($data) {
+
+                        if (! array_key_exists('allianceID', $data))
+                            return;
+
+                        $field->title('Alliance')
+                            ->content(
+                                $this->zKillBoardToSlackLink(
+                                    'alliance',
+                                    $data['allianceID'],
+                                    $data['allianceName']
+                                ));
+                    })
+                    ->field(function ($field) use ($data) {
+
+                        $system = MapDenormalize::find($data['solarsystemID']);
+
+                        $field->title('System')
+                            ->content(
+                                $this->zKillBoardToSlackLink(
+                                    'system',
+                                    $system->itemID,
+                                    $system->itemName . ' (' . number_format($system->security, 2) . ')'
+                                ));
+                    })
+                    ->field(function ($field) use ($data) {
+
+                        $structure = UniverseStructure::find($data['structureID']);
+
+                        $type = InvType::find($data['structureShowInfoData'][1]);
+
+                        $title = 'Structure';
+
+                        if (! is_null($structure))
+                            $title = $structure->name;
+
+                        $field->title($title)
+                            ->content($type->typeName);
+                    });
+            })
+            ->attachment(function ($attachment) use ($data) {
+                $attachment->field(function ($field) use ($data) {
+                    $field->title('Shield')
+                        ->content(number_format($data['shieldPercentage'], 2));
+                })->color('good');
+
+                if ($data['shieldPercentage'] < 70)
+                    $attachment->color('warning');
+
+                if ($data['shieldPercentage'] < 40)
+                    $attachment->color('danger');
+            })
+            ->attachment(function ($attachment) use ($data) {
+                $attachment->field(function ($field) use ($data) {
+                    $field->title('Armor')
+                        ->content(number_format($data['armorPercentage'], 2));
+                })->color('good');
+
+                if ($data['armorPercentage'] < 70)
+                    $attachment->color('warning');
+
+                if ($data['armorPercentage'] < 40)
+                    $attachment->color('danger');
+            })
+            ->attachment(function ($attachment) use ($data) {
+                $attachment->field(function ($field) use ($data) {
+                    $field->title('Hull')
+                        ->content(number_format($data['hullPercentage'], 2));
+                })->color('good');
+
+                if ($data['hullPercentage'] < 70)
+                    $attachment->color('warning');
+
+                if ($data['hullPercentage'] < 40)
+                    $attachment->color('danger');
+            });
+    }
+
+    /**
+     * @param $notifiable
+     * @return mixed
+     */
+    public function toArray($notifiable)
+    {
+        return yaml_parse($this->notification->text);
+    }
+
+    /**
+     * Build a link to zKillboard using Slack message formatting.
+     *
+     * @param string $type (must be ship, character, corporation or alliance)
+     * @param int    $id   the type entity ID
+     * @param string $name the type name
+     *
+     * @return string
+     */
+    private function zKillBoardToSlackLink(string $type, int $id, string $name)
+    {
+
+        if (! in_array($type, ['ship', 'character', 'corporation', 'alliance', 'kill', 'system']))
+            return '';
+
+        return sprintf('<https://zkillboard.com/%s/%d/|%s>', $type, $id, $name);
+    }
+}

--- a/src/Notifications/StructureUnderAttack.php
+++ b/src/Notifications/StructureUnderAttack.php
@@ -22,9 +22,9 @@
 
 namespace Seat\Notifications\Notifications;
 
+use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Notification;
-use Seat\Eveapi\Models\Character\MailMessage;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
 use Seat\Eveapi\Models\Universe\UniverseStructure;
@@ -58,7 +58,7 @@ class StructureUnderAttack extends Notification
 
     /**
      * @param $notifiable
-     * @return mixed
+     * @return \Illuminate\Notifications\Messages\MailMessage
      */
     public function toMail($notifiable)
     {
@@ -88,7 +88,7 @@ class StructureUnderAttack extends Notification
 
     /**
      * @param $notifiable
-     * @return SlackMessage
+     * @return \Illuminate\Notifications\Messages\SlackMessage
      */
     public function toSlack($notifiable)
     {


### PR DESCRIPTION
BREAKING CHANGES: PECL yaml extension is now required in order to parse CCP notifications
DEPENDENCIES eveseat/docker-eveseat-app#5 eveseat/docker-eveseat-worker#3 eveseat/scripts#28

Rendered this way under Slack

![image](https://user-images.githubusercontent.com/648753/58559066-90b83100-8222-11e9-9244-c76f2d591248.png)

Rendered this way under Discord

![image](https://user-images.githubusercontent.com/648753/58561677-ea6f2a00-8227-11e9-835f-5d6afb6bd53a.png)
