### PR TITLE
feat(notifications): add sovereignty structure destroyed support

### DIFF
--- a/src/Alerts/Char/SovStructureDestroyed.php
+++ b/src/Alerts/Char/SovStructureDestroyed.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015, 2016, 2017, 2018, 2019  Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Notifications\Alerts\Char;
+
+use Illuminate\Support\Collection;
+use Seat\Eveapi\Models\Character\CharacterNotification;
+use Seat\Notifications\Alerts\Base;
+
+class SovStructureDestroyed extends Base
+{
+
+    /**
+     * The field to use from the data when trying
+     * to infer an affiliation.
+     *
+     * @return string
+     */
+    public function getAffiliationField()
+    {
+        return 'character_id';
+    }
+
+    /**
+     * The required method to handle the Alert.
+     *
+     * @return mixed
+     */
+    protected function getData(): Collection
+    {
+        return CharacterNotification::where('timestamp', '>', carbon('now')->subWeek())
+            ->where('type', 'SovStructureDestroyed')
+            ->get();
+    }
+
+    /**
+     * The name of the alert. This is also the name
+     * of the notifier to use.
+     *
+     * @return string
+     */
+    protected function getName(): string
+    {
+        return 'sovstructuredestroyed';
+    }
+
+    /**
+     * The type of notification.
+     *
+     * @return string
+     */
+    protected function getType(): string
+    {
+        return 'char';
+    }
+
+    /**
+     * Fields in a collection row that make the alert
+     * unique.
+     *
+     * @return array
+     */
+    protected function getUniqueFields(): array
+    {
+        return ['character_id', 'notification_id'];
+    }
+}

--- a/src/Alerts/Char/SovStructureDestroyed.php
+++ b/src/Alerts/Char/SovStructureDestroyed.php
@@ -28,7 +28,6 @@ use Seat\Notifications\Alerts\Base;
 
 class SovStructureDestroyed extends Base
 {
-
     /**
      * The field to use from the data when trying
      * to infer an affiliation.

--- a/src/Config/notifications.alerts.php
+++ b/src/Config/notifications.alerts.php
@@ -35,6 +35,11 @@ return [
             'alert'    => \Seat\Notifications\Alerts\Char\NewMailMessage::class,
             'notifier' => \Seat\Notifications\Notifications\NewMailMessage::class,
         ],
+        'sovstructuredestroyed' => [
+            'name'     => 'Sovereignty Structure Destroyed',
+            'alert'    => \Seat\Notifications\Alerts\Char\SovStructureDestroyed::class,
+            'notifier' => \Seat\Notifications\Notifications\SovStructureDestroyed::class,
+        ],
     ],
     'corp' => [
 

--- a/src/Notifications/AbstractNotification.php
+++ b/src/Notifications/AbstractNotification.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015, 2016, 2017, 2018, 2019  Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Notifications\Notifications;
+
+use Illuminate\Notifications\Notification;
+
+abstract class AbstractNotification extends Notification
+{
+    /**
+     * Build a link to zKillboard using Slack message formatting.
+     *
+     * @param string $type (must be ship, character, corporation or alliance)
+     * @param int    $id   the type entity ID
+     * @param string $name the type name
+     *
+     * @return string
+     */
+    protected function zKillBoardToSlackLink(string $type, int $id, string $name)
+    {
+        if (! in_array($type, ['ship', 'character', 'corporation', 'alliance', 'kill', 'system']))
+            return '';
+
+        return sprintf('<https://zkillboard.com/%s/%d/|%s>', $type, $id, $name);
+    }
+}

--- a/src/Notifications/SovStructureDestroyed.php
+++ b/src/Notifications/SovStructureDestroyed.php
@@ -108,7 +108,7 @@ class SovStructureDestroyed extends AbstractNotification
     /**
      * @return array
      */
-    public function toArray()
+    public function toArray($notifiable)
     {
         return yaml_parse($this->notification->text);
     }

--- a/src/Notifications/SovStructureDestroyed.php
+++ b/src/Notifications/SovStructureDestroyed.php
@@ -104,4 +104,12 @@ class SovStructureDestroyed extends AbstractNotification
                 });
             })->error();
     }
+
+    /**
+     * @return array
+     */
+    public function toArray()
+    {
+        return yaml_parse($this->notification->text);
+    }
 }

--- a/src/Notifications/SovStructureDestroyed.php
+++ b/src/Notifications/SovStructureDestroyed.php
@@ -106,6 +106,7 @@ class SovStructureDestroyed extends AbstractNotification
     }
 
     /**
+     * @param $notifiable
      * @return array
      */
     public function toArray($notifiable)

--- a/src/Notifications/SovStructureDestroyed.php
+++ b/src/Notifications/SovStructureDestroyed.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015, 2016, 2017, 2018, 2019  Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Notifications\Notifications;
+
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Messages\SlackMessage;
+use Seat\Eveapi\Models\Sde\InvType;
+use Seat\Eveapi\Models\Sde\MapDenormalize;
+
+class SovStructureDestroyed extends AbstractNotification
+{
+    /**
+     * @var \Seat\Eveapi\Models\Character\CharacterNotification
+     */
+    private $notification;
+
+    public function __construct($notification)
+    {
+        $this->notification = $notification;
+    }
+
+    /**
+     * @param $notifiable
+     * @return mixed
+     */
+    public function via($notifiable)
+    {
+        return $notifiable->notificationChannels();
+    }
+
+    /**
+     * @param $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        $data = yaml_parse($this->notification->text);
+
+        $type = InvType::find($data['structureTypeID']);
+
+        $system = MapDenormalize::find($data['solarSystemID']);
+
+        return (new MailMessage)
+            ->subject('Sovereignty Structure Destroyed Notification!')
+            ->line(
+                sprintf('A sovereignty structure has been destroyed (%s)!', $type->typeName))
+            ->action(
+                sprintf('System : %s (%s)', $system->itemName, number_format($system->security, 2)),
+                sprintf('https://zkillboard.com/%s/%d', 'system', $system->itemID));
+    }
+
+    /**
+     * @param $notifiable
+     * @return \Illuminate\Notifications\Messages\SlackMessage
+     */
+    public function toSlack($notifiable)
+    {
+        $data = yaml_parse($this->notification->text);
+
+        return (new SlackMessage)
+            ->content('A sovereignty structure has been destroyed!')
+            ->from('SeAT SovStructureDestroyed')
+            ->attachment(function ($attachment) use ($data) {
+
+                $attachment->field(function ($field) use ($data) {
+
+                    $system = MapDenormalize::find($data['solarSystemID']);
+
+                    $field->title('System')
+                        ->content(
+                            $this->zKillBoardToSlackLink(
+                                'system',
+                                $system->itemID,
+                                sprintf('%s (%s)', $system->itemName, number_format($system->security, 2))
+                            )
+                        );
+                })
+                ->field(function ($field) use ($data) {
+
+                    $type = InvType::find($data['structureTypeID']);
+
+                    $field->title('Structure')
+                        ->content($type->typeName);
+                });
+            })->error();
+    }
+}


### PR DESCRIPTION
BREAKING CHANGES: PECL yaml extension is now required in order to parse CCP notifications
DEPENDENCIES: eveseat/notifications#26 eveseat/docker-eveseat-app#5 eveseat/docker-eveseat-worker#3 eveseat/scripts#28