### PR TITLE
feat(notifications): add corporation bill notification support

### DIFF
--- a/src/Alerts/Char/CorpAllBillMsg.php
+++ b/src/Alerts/Char/CorpAllBillMsg.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015, 2016, 2017, 2018, 2019  Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Notifications\Alerts\Char;
+
+use Illuminate\Support\Collection;
+use Seat\Eveapi\Models\Character\CharacterNotification;
+use Seat\Notifications\Alerts\Base;
+
+class CorpAllBillMsg extends Base
+{
+    /**
+     * The field to use from the data when trying
+     * to infer an affiliation.
+     *
+     * @return string
+     */
+    public function getAffiliationField()
+    {
+        return 'character_id';
+    }
+
+    /**
+     * The required method to handle the Alert.
+     *
+     * @return mixed
+     */
+    protected function getData(): Collection
+    {
+        return CharacterNotification::where('timestamp', '>', carbon('now')->subWeek())
+            ->where('type', 'CorpAllBillMsg')
+            ->get();
+    }
+
+    /**
+     * The name of the alert. This is also the name
+     * of the notifier to use.
+     *
+     * @return string
+     */
+    protected function getName(): string
+    {
+        return 'corpallbillmsg';
+    }
+
+    /**
+     * The type of notification.
+     *
+     * @return string
+     */
+    protected function getType(): string
+    {
+        return 'char';
+    }
+
+    /**
+     * Fields in a collection row that make the alert
+     * unique.
+     *
+     * @return array
+     */
+    protected function getUniqueFields(): array
+    {
+        return ['character_id', 'notification_id'];
+    }
+}

--- a/src/Config/notifications.alerts.php
+++ b/src/Config/notifications.alerts.php
@@ -35,6 +35,11 @@ return [
             'alert'    => \Seat\Notifications\Alerts\Char\NewMailMessage::class,
             'notifier' => \Seat\Notifications\Notifications\NewMailMessage::class,
         ],
+        'corpallbillmsg' => [
+            'name' => 'Corporation Bill',
+            'alert' => \Seat\Notifications\Alerts\Char\CorpAllBillMsg::class,
+            'notifier' => \Seat\Notifications\Notifications\CorpAllBillMsg::class,
+        ],
     ],
     'corp' => [
 

--- a/src/Notifications/CorpAllBillMsg.php
+++ b/src/Notifications/CorpAllBillMsg.php
@@ -148,9 +148,10 @@ class CorpAllBillMsg extends AbstractNotification
     }
 
     /**
+     * @param $notifiable
      * @return array
      */
-    public function toArray()
+    public function toArray($notifiable)
     {
         return yaml_parse($this->notification->text);
     }

--- a/src/Notifications/CorpAllBillMsg.php
+++ b/src/Notifications/CorpAllBillMsg.php
@@ -1,0 +1,157 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015, 2016, 2017, 2018, 2019  Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Notifications\Notifications;
+
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Messages\SlackMessage;
+use Seat\Eveapi\Models\Alliances\Alliance;
+use Seat\Eveapi\Models\Corporation\CorporationInfo;
+
+class CorpAllBillMsg extends AbstractNotification
+{
+    /**
+     * @var \Seat\Eveapi\Models\Character\CharacterNotification
+     */
+    private $notification;
+
+    /**
+     * CorpAllBillMsg constructor.
+     *
+     * @param $notification
+     */
+    public function __construct($notification)
+    {
+        $this->notification = $notification;
+    }
+
+    /**
+     * @param $notifiable
+     * @return mixed
+     */
+    public function via($notifiable)
+    {
+        return $notifiable->notificationChannels();
+    }
+
+    /**
+     * @param $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        $data = yaml_parse($this->notification->text);
+
+        $mail = (new MailMessage)
+            ->subject('Corporation Bill Notification!')
+            ->line('A new corporation bill has been issued!')
+            ->line(
+                sprintf('Amount: %s - Due on %s',
+                    number_format($data['amount'], 2),
+                    $this->mssqlTimestampToDate($data['dueDate'])->toRfc7231String())
+            );
+
+        $entity = Alliance::find($data['creditorID']);
+
+        if (is_null($entity))
+            CorporationInfo::find($data['creditorID']);
+
+        if (! is_null($entity))
+            $mail->action(
+                sprintf('Due to: %s', $entity->name),
+                sprintf('https://zkillboard.com/%s/%d', 'corporation', $entity->id));
+
+        $entity = Alliance::find($data['debtorID']);
+
+        if (is_null($entity))
+            CorporationInfo::find($data['debtorID']);
+
+        if (! is_null($entity))
+            $mail->action(
+                sprintf('Due by: %s', $entity->name),
+                sprintf('https://zkillboard.com/%s/%d', 'corporation', $entity->id));
+
+        return $mail;
+    }
+
+    /**
+     * @param $notifiable
+     * @return \Illuminate\Notifications\Messages\SlackMessage
+     */
+    public function toSlack($notifiable)
+    {
+        return (new SlackMessage)
+            ->content('A new corporation bill has been issued!')
+            ->from('SeAT CorpAllBillMsg')
+            ->attachment(function ($attachment) {
+
+                $data = yaml_parse($this->notification->text);
+
+                $attachment->field(function ($field) use ($data) {
+
+                    $field->title('Amount')
+                        ->content(number_format($data['amount'], 2));
+
+                })
+                ->field(function ($field) use ($data) {
+
+                    $field->title('Due Date')
+                        ->content($this->mssqlTimestampToDate($data['dueDate'])->toRfc7231String());
+
+                });
+
+                $entity = Alliance::find($data['creditorID']);
+
+                if (is_null($entity))
+                    CorporationInfo::find($data['creditorID']);
+
+                if (! is_null($entity))
+                    $attachment->field(function ($field) use ($entity) {
+
+                        $field->title('Due To')
+                            ->content($entity->name);
+
+                    });
+
+                $entity = Alliance::find($data['debtorID']);
+
+                if (is_null($entity))
+                    CorporationInfo::find($data['debtorID']);
+
+                if (! is_null($entity))
+                    $attachment->field(function ($field) use ($entity) {
+
+                        $field->title('Due By')
+                            ->content($entity->name);
+
+                    });
+            });
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray()
+    {
+        return yaml_parse($this->notification->text);
+    }
+}


### PR DESCRIPTION
BREAKING CHANGES: PECL yaml extension is now required in order to parse CCP notifications
DEPENDENCIES: eveseat/notifications#28 eveseat/docker-eveseat-app#5 eveseat/docker-eveseat-worker#3 eveseat/scripts#28