### PR TITLE
feat(notifications): add moon mining extraction notification support

### DIFF
--- a/src/Alerts/Char/MoonMiningExtractionFinished.php
+++ b/src/Alerts/Char/MoonMiningExtractionFinished.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015, 2016, 2017, 2018, 2019  Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Notifications\Alerts\Char;
+
+use Illuminate\Support\Collection;
+use Seat\Eveapi\Models\Character\CharacterNotification;
+use Seat\Notifications\Alerts\Base;
+
+class MoonMiningExtractionFinished extends Base
+{
+    /**
+     * The field to use from the data when trying
+     * to infer an affiliation.
+     *
+     * @return string
+     */
+    public function getAffiliationField()
+    {
+        return 'character_id';
+    }
+
+    /**
+     * The required method to handle the Alert.
+     *
+     * @return mixed
+     */
+    protected function getData(): Collection
+    {
+        return CharacterNotification::where('timestamp', '>', carbon('now')->subWeek())
+            ->where('type', 'MoonminingExtractionFinished')
+            ->get();
+    }
+
+    /**
+     * The name of the alert. This is also the name
+     * of the notifier to use.
+     *
+     * @return string
+     */
+    protected function getName(): string
+    {
+        return 'moonminingextractionfinished';
+    }
+
+    /**
+     * The type of notification.
+     *
+     * @return string
+     */
+    protected function getType(): string
+    {
+        return 'char';
+    }
+
+    /**
+     * Fields in a collection row that make the alert
+     * unique.
+     *
+     * @return array
+     */
+    protected function getUniqueFields(): array
+    {
+        return ['character_id', 'notification_id'];
+    }
+}

--- a/src/Config/notifications.alerts.php
+++ b/src/Config/notifications.alerts.php
@@ -35,6 +35,11 @@ return [
             'alert'    => \Seat\Notifications\Alerts\Char\NewMailMessage::class,
             'notifier' => \Seat\Notifications\Notifications\NewMailMessage::class,
         ],
+        'moonminingextractionfinished' => [
+            'name'     => 'Moon Extraction Finished',
+            'alert'    => \Seat\Notifications\Alerts\Char\MoonMiningExtractionFinished::class,
+            'notifier' => \Seat\Notifications\Notifications\MoonMiningExtractionFinished::class,
+        ],
     ],
     'corp' => [
 

--- a/src/Notifications/MoonMiningExtractionFinished.php
+++ b/src/Notifications/MoonMiningExtractionFinished.php
@@ -177,7 +177,7 @@ class MoonMiningExtractionFinished extends AbstractNotification
                 })->field(function ($field) use ($data) {
 
                     $field->title('Self Fractured')
-                        ->content($this->mssqlTimestampToDate($data['autoTime']));
+                        ->content($this->mssqlTimestampToDate($data['autoTime'])->toRfc7231String());
 
                 });
             });

--- a/src/Notifications/MoonMiningExtractionFinished.php
+++ b/src/Notifications/MoonMiningExtractionFinished.php
@@ -174,6 +174,11 @@ class MoonMiningExtractionFinished extends AbstractNotification
                         ->content(
                             sprintf('%s (%s)', $data['structureName'], $type->typeName));
 
+                })->field(function ($field) use ($data) {
+
+                    $field->title('Self Fractured')
+                        ->content($this->mssqlTimestampToDate($data['autoTime']));
+
                 });
             });
 

--- a/src/Notifications/MoonMiningExtractionFinished.php
+++ b/src/Notifications/MoonMiningExtractionFinished.php
@@ -1,0 +1,214 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015, 2016, 2017, 2018, 2019  Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Notifications\Notifications;
+
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Messages\SlackMessage;
+use Seat\Eveapi\Models\Sde\InvType;
+use Seat\Eveapi\Models\Sde\MapDenormalize;
+
+class MoonMiningExtractionFinished extends AbstractNotification
+{
+    /**
+     * @var \Seat\Eveapi\Models\Character\CharacterNotification
+     */
+    private $notification;
+
+    /**
+     * MoonMiningExtractionFinished constructor.
+     *
+     * @param $notification
+     */
+    public function __construct($notification)
+    {
+        $this->notification = $notification;
+    }
+
+    /**
+     * @param $notifiable
+     * @return mixed
+     */
+    public function via($notifiable)
+    {
+        return $notifiable->notificationChannels();
+    }
+
+    /**
+     * @param $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        $data = yaml_parse($this->notification->text);
+
+        $system = MapDenormalize::find($data['solarSystemID']);
+
+        $moon = MapDenormalize::find($data['moonID']);
+
+        $type = InvType::find($data['structureTypeID']);
+
+        $mail = (new MailMessage)
+            ->subject('Moon Mining Extraction Finished Notification!')
+            ->line(
+                sprintf('A Moon Mining Extraction operated on %s (%s) - %s has been successfully completed.',
+                    $system->itemName, number_format($system->security, 2), $moon->itemName)
+            )
+        ->line(
+            sprintf('The structure %s (%s) has reported the content bellow:',
+                $data['structureName'], $type->typeName)
+        );
+
+        foreach ($data['oreVolumeByType'] as $type_id => $volume) {
+            $type = InvType::find($type_id);
+
+            $mail->line(
+                sprintf(' - %s : %s', $type->typeName, number_format($volume, 2))
+            );
+        }
+
+        $mail->line(
+            sprintf('Hurry up, you have until the %s to collect them!',
+                $this->mssqlTimestampToDate($data['autoTime'])->toRfc7231String())
+        );
+
+        return $mail;
+    }
+
+    /**
+     * @param $notifiable
+     * @return \Illuminate\Notifications\Messages\SlackMessage
+     */
+    public function toSlack($notifiable)
+    {
+        $data = yaml_parse($this->notification->text);
+
+        $ore_categories = [
+            '#00a65a' => [],  // Gaz
+            '#3c8dbc' => [],  // R8
+            '#00c0ef' => [],  // R16
+            '#f39c12' => [],  // R32
+            '#dd4b39' => [],  // R64
+            '#d2d6de' => [],  // Ore
+        ];
+
+        // build a color per category array
+        foreach ($data['oreVolumeByType'] as $type_id => $volume) {
+            $type = InvType::find($type_id);
+
+            switch ($type->marketGroupID) {
+                // Gaz
+                case 2396:
+                    $ore_categories['#00a65a'][$type_id] = $volume;
+                    break;
+                // R8
+                case 2397:
+                    $ore_categories['#3c8dbc'][$type_id] = $volume;
+                    break;
+                // R16
+                case 2398:
+                    $ore_categories['#00c0ef'][$type_id] = $volume;
+                    break;
+                // R32
+                case 2400:
+                    $ore_categories['#f39c12'][$type_id] = $volume;
+                    break;
+                // R64
+                case 2401:
+                    $ore_categories['#dd4b39'][$type_id] = $volume;
+                    break;
+                // Ore
+                default:
+                    $ore_categories['#d2d6de'][$type_id] = $volume;
+            }
+        }
+
+        $message = (new SlackMessage)
+            ->content('A Moon Mining Extraction has been successfully completed.')
+            ->from('SeAT MoonMiningExtractionFinished')
+            ->attachment(function ($attachment) use ($data) {
+
+                $attachment->field(function ($field) use ($data) {
+
+                    $system = MapDenormalize::find($data['solarSystemID']);
+
+                    $field->title('System')
+                        ->content(
+                            $this->zKillBoardToSlackLink(
+                                'system',
+                                $system->itemID,
+                                sprintf('%s (%s)', $system->itemName, number_format($system->security, 2))
+                            ));
+
+                })->field(function ($field) use ($data) {
+
+                    $moon = MapDenormalize::find($data['moonID']);
+
+                    $field->title('Moon')
+                        ->content($moon->itemName);
+
+                })->field(function ($field) use ($data) {
+
+                    $type = InvType::find($data['structureTypeID']);
+
+                    $field->title('Structure')
+                        ->content(
+                            sprintf('%s (%s)', $data['structureName'], $type->typeName));
+
+                });
+            });
+
+        foreach ($ore_categories as $color => $ore) {
+            if (! empty($ore)) {
+
+                $message->attachment(function ($attachment) use ($color, $ore) {
+
+                    $attachment->color($color);
+
+                    foreach ($ore as $type_id => $volume) {
+
+                        $attachment->field(function ($field) use ($type_id, $volume) {
+
+                            $type = InvType::find($type_id);
+
+                            $field->title($type->typeName)
+                                ->content(
+                                    sprintf('%s m3', number_format($volume, 2)));
+
+                        });
+                    }
+                });
+            }
+        }
+
+        return $message;
+    }
+
+    /**
+     * @param $notifiable
+     * @return array
+     */
+    public function toArray($notifiable)
+    {
+        return yaml_parse($this->notification->text);
+    }
+}


### PR DESCRIPTION
BREAKING CHANGES: PECL yaml extension is now required in order to parse CCP notifications
DEPENDENCIES: eveseat/notifications#28 eveseat/docker-eveseat-app#5 eveseat/docker-eveseat-worker#3 eveseat/scripts#28

Slack rendering
![image](https://user-images.githubusercontent.com/648753/58697064-2d9cda80-8399-11e9-9866-82c85c767388.png)

Discord rendering
![image](https://user-images.githubusercontent.com/648753/58697150-51f8b700-8399-11e9-9abe-2d5a2b7d1283.png)
