### PR TITLE
feat(notifications): add structure service offline notification support

### DIFF
--- a/src/Alerts/Char/StructureServicesOffline.php
+++ b/src/Alerts/Char/StructureServicesOffline.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015, 2016, 2017, 2018, 2019  Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Notifications\Alerts\Char;
+
+use Illuminate\Support\Collection;
+use Seat\Eveapi\Models\Character\CharacterNotification;
+use Seat\Notifications\Alerts\Base;
+
+class StructureServicesOffline extends Base
+{
+    /**
+     * The field to use from the data when trying
+     * to infer an affiliation.
+     *
+     * @return string
+     */
+    public function getAffiliationField()
+    {
+        return 'character_id';
+    }
+
+    /**
+     * The required method to handle the Alert.
+     *
+     * @return mixed
+     */
+    protected function getData(): Collection
+    {
+        return CharacterNotification::where('timestamp', '>', carbon('now')->subWeek())
+            ->where('type', 'StructureServicesOffline')
+            ->get();
+    }
+
+    /**
+     * The name of the alert. This is also the name
+     * of the notifier to use.
+     *
+     * @return string
+     */
+    protected function getName(): string
+    {
+        return 'structureservicesofflines';
+    }
+
+    /**
+     * The type of notification.
+     *
+     * @return string
+     */
+    protected function getType(): string
+    {
+        return 'char';
+    }
+
+    /**
+     * Fields in a collection row that make the alert
+     * unique.
+     *
+     * @return array
+     */
+    protected function getUniqueFields(): array
+    {
+        return ['character_id', 'notification_id'];
+    }
+}

--- a/src/Config/notifications.alerts.php
+++ b/src/Config/notifications.alerts.php
@@ -35,6 +35,11 @@ return [
             'alert'    => \Seat\Notifications\Alerts\Char\NewMailMessage::class,
             'notifier' => \Seat\Notifications\Notifications\NewMailMessage::class,
         ],
+        'structureservicesofflines' => [
+            'name'     => 'Structure Services Offline',
+            'alert'    => \Seat\Notifications\Alerts\Char\StructureServicesOffline::class,
+            'notifier' => \Seat\Notifications\Notifications\StructureServicesOffline::class,
+        ],
     ],
     'corp' => [
 

--- a/src/Notifications/StructureServicesOffline.php
+++ b/src/Notifications/StructureServicesOffline.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015, 2016, 2017, 2018, 2019  Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Notifications\Notifications;
+
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Messages\SlackMessage;
+use Seat\Eveapi\Models\Sde\InvType;
+use Seat\Eveapi\Models\Sde\MapDenormalize;
+
+class StructureServicesOffline extends AbstractNotification
+{
+    /**
+     * @var \Seat\Eveapi\Models\Character\CharacterNotification
+     */
+    private $notification;
+
+    /**
+     * StructureServicesOffline constructor.
+     *
+     * @param $notification
+     */
+    public function __construct($notification)
+    {
+        $this->notification = $notification;
+    }
+
+    /**
+     * @param $notifiable
+     * @return mixed
+     */
+    public function via($notifiable)
+    {
+        return $notifiable->notificationChannels();
+    }
+
+    /**
+     * @param $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        $data = yaml_parse($this->notification->text);
+
+        $system = MapDenormalize::find($data['solarsystemID']);
+
+        $mail = (new MailMessage)
+            ->subject('Structure Services Offline Notification!')
+            ->line(
+                sprintf('A structure service has been shutdown in the system %s (%s)!',
+                    $system->itemName, number_format($system->security, 2)))
+            ->line('The following modules are concerned :');
+
+        foreach ($data['listOfServiceModuleIDs'] as $type_id) {
+            $type = InvType::find($type_id);
+
+            $mail->line(sprintf(' - %s', $type->typeName));
+        }
+
+        return $mail;
+    }
+
+    /**
+     * @param $notifiable
+     * @return \Illuminate\Notifications\Messages\SlackMessage
+     */
+    public function toSlack($notifiable)
+    {
+        $data = yaml_parse($this->notification->text);
+
+        return (new SlackMessage)
+            ->content('A structure service has been shutdown!')
+            ->from('SeAT StructureServicesOffline')
+            ->attachment(function ($attachment) use ($data) {
+
+                $attachment->field(function ($field) use ($data) {
+
+                    $system = MapDenormalize::find($data['solarsystemID']);
+
+                    $field->title('System')
+                        ->content(
+                            $this->zKillBoardToSlackLink(
+                                'system',
+                                $system->itemID,
+                                sprintf('%s (%s)', $system->itemName, $system->security)
+                            )
+                        );
+                })->field(function ($field) use ($data) {
+
+                    $type = InvType::find($data['structureShowInfoData'][1]);
+
+                    $field->title('Structure')
+                        ->content($type->typeName);
+
+                });
+
+            })->attachment(function ($attachment) use ($data) {
+
+                foreach ($data['listOfServiceModuleIDs'] as $type_id) {
+                    $attachment->field(function ($field) use ($type_id) {
+
+                            $type = InvType::find($type_id);
+
+                            $field->content($type->typeName);
+
+                    });
+                }
+
+                $attachment->color('danger');
+            });
+    }
+
+    /**
+     * @param $notifiable
+     * @return array
+     */
+    public function toArray($notifiable)
+    {
+        return yaml_parse($this->notification->text);
+    }
+}


### PR DESCRIPTION
BREAKING CHANGES: PECL yaml extension is now required in order to parse CCP notifications
DEPENDENCIES: eveseat/notifications#28 eveseat/docker-eveseat-app#5 eveseat/docker-eveseat-worker#3 eveseat/scripts#28

Slack rendering

![image](https://user-images.githubusercontent.com/648753/58745265-0bfe2a80-844f-11e9-8ea6-3e48d5a6c66e.png)

Discord rendering

![image](https://user-images.githubusercontent.com/648753/58745274-2b955300-844f-11e9-84cc-c6679b5500d9.png)
