### PR TITLE
feat(notifications): add corporation character left notification support

### DIFF
--- a/src/Alerts/Char/CharLeftCorpMsg.php
+++ b/src/Alerts/Char/CharLeftCorpMsg.php
@@ -38,6 +38,7 @@ class CharLeftCorpMsg extends Base
     {
         return 'character_id';
     }
+
     /**
      * The required method to handle the Alert.
      *
@@ -49,6 +50,7 @@ class CharLeftCorpMsg extends Base
             ->where('type', 'CharLeftCorpMsg')
             ->get();
     }
+
     /**
      * The name of the alert. This is also the name
      * of the notifier to use.
@@ -59,6 +61,7 @@ class CharLeftCorpMsg extends Base
     {
         return 'charleftcorpmsg';
     }
+
     /**
      * The type of notification.
      *
@@ -68,6 +71,7 @@ class CharLeftCorpMsg extends Base
     {
         return 'char';
     }
+
     /**
      * Fields in a collection row that make the alert
      * unique.

--- a/src/Alerts/Char/CharLeftCorpMsg.php
+++ b/src/Alerts/Char/CharLeftCorpMsg.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015, 2016, 2017, 2018, 2019  Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Notifications\Alerts\Char;
+
+use Illuminate\Support\Collection;
+use Seat\Eveapi\Models\Character\CharacterNotification;
+use Seat\Notifications\Alerts\Base;
+
+class CharLeftCorpMsg extends Base
+{
+    /**
+     * The field to use from the data when trying
+     * to infer an affiliation.
+     *
+     * @return string
+     */
+    public function getAffiliationField()
+    {
+        return 'character_id';
+    }
+    /**
+     * The required method to handle the Alert.
+     *
+     * @return mixed
+     */
+    protected function getData(): Collection
+    {
+        return CharacterNotification::where('timestamp', '>', carbon('now')->subWeek())
+            ->where('type', 'CharLeftCorpMsg')
+            ->get();
+    }
+    /**
+     * The name of the alert. This is also the name
+     * of the notifier to use.
+     *
+     * @return string
+     */
+    protected function getName(): string
+    {
+        return 'charleftcorpmsg';
+    }
+    /**
+     * The type of notification.
+     *
+     * @return string
+     */
+    protected function getType(): string
+    {
+        return 'char';
+    }
+    /**
+     * Fields in a collection row that make the alert
+     * unique.
+     *
+     * @return array
+     */
+    protected function getUniqueFields(): array
+    {
+        return ['character_id', 'notification_id'];
+    }
+}

--- a/src/Config/notifications.alerts.php
+++ b/src/Config/notifications.alerts.php
@@ -35,6 +35,11 @@ return [
             'alert'    => \Seat\Notifications\Alerts\Char\NewMailMessage::class,
             'notifier' => \Seat\Notifications\Notifications\NewMailMessage::class,
         ],
+        'charleftcorpmsg' => [
+            'name'     => 'Character Left Corporation',
+            'alert'    => \Seat\Notifications\Alerts\Char\CharLeftCorpMsg::class,
+            'notifier' => \Seat\Notifications\Notifications\CharLeftCorpMsg::class,
+        ],
     ],
     'corp' => [
 

--- a/src/Notifications/CharLeftCorpMsg.php
+++ b/src/Notifications/CharLeftCorpMsg.php
@@ -27,6 +27,7 @@ use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Notification;
 use Seat\Eveapi\Models\Character\CharacterInfo;
 use Seat\Eveapi\Models\Corporation\CorporationInfo;
+use Symfony\Component\Yaml\Yaml;
 
 class CharLeftCorpMsg extends Notification
 {
@@ -36,6 +37,11 @@ class CharLeftCorpMsg extends Notification
     private $notification;
 
     /**
+     * @var mixed
+     */
+    private $content;
+
+    /**
      * CharLeftCorpMsg constructor.
      *
      * @param $notification
@@ -43,6 +49,7 @@ class CharLeftCorpMsg extends Notification
     public function __construct($notification)
     {
         $this->notification = $notification;
+        $this->content = Yaml::parse($this->notification->text);
     }
 
     /**
@@ -60,15 +67,13 @@ class CharLeftCorpMsg extends Notification
      */
     public function toMail($notifiable)
     {
-        $data = yaml_parse($this->notification->text);
-
         $mail = (new MailMessage)
             ->subject('Character Left Corp Notification!')
             ->line('A character has left the corporation!');
 
-        $character = CharacterInfo::find($data['charID']);
+        $character = CharacterInfo::find($this->content['charID']);
 
-        $corporation = CorporationInfo::find($data['corpID']);
+        $corporation = CorporationInfo::find($this->content['corpID']);
 
         if (! is_null($corporation) && ! is_null($character)) {
 
@@ -96,15 +101,13 @@ class CharLeftCorpMsg extends Notification
      */
     public function toSlack($notifiable)
     {
-        $data = yaml_parse($this->notification->text);
-
         $message = (new SlackMessage)
             ->content('A character has left corporation!')
             ->from('SeAT CharLeftCorpMsg');
 
-        $character = CharacterInfo::find($data['charID']);
+        $character = CharacterInfo::find($this->content['charID']);
 
-        $corporation = CorporationInfo::find($data['corpID']);
+        $corporation = CorporationInfo::find($this->content['corpID']);
 
         if (! is_null($corporation) && ! is_null($character)) {
 
@@ -141,6 +144,6 @@ class CharLeftCorpMsg extends Notification
      */
     public function toArray($notifiable)
     {
-        return yaml_parse($this->notification->text);
+        return $this->content;
     }
 }

--- a/src/Notifications/CharLeftCorpMsg.php
+++ b/src/Notifications/CharLeftCorpMsg.php
@@ -1,0 +1,146 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015, 2016, 2017, 2018, 2019  Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Notifications\Notifications;
+
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Messages\SlackMessage;
+use Illuminate\Notifications\Notification;
+use Seat\Eveapi\Models\Character\CharacterInfo;
+use Seat\Eveapi\Models\Corporation\CorporationInfo;
+
+class CharLeftCorpMsg extends Notification
+{
+    /**
+     * @var \Seat\Eveapi\Models\Character\CharacterNotification
+     */
+    private $notification;
+
+    /**
+     * CharLeftCorpMsg constructor.
+     *
+     * @param $notification
+     */
+    public function __construct($notification)
+    {
+        $this->notification = $notification;
+    }
+
+    /**
+     * @param $notifiable
+     * @return mixed
+     */
+    public function via($notifiable)
+    {
+        return $notifiable->notificationChannels();
+    }
+
+    /**
+     * @param $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        $data = yaml_parse($this->notification->text);
+
+        $mail = (new MailMessage)
+            ->subject('Character Left Corp Notification!')
+            ->line('A character has left the corporation!');
+
+        $character = CharacterInfo::find($data['charID']);
+
+        $corporation = CorporationInfo::find($data['corpID']);
+
+        if (! is_null($corporation) && ! is_null($character)) {
+
+            if (! is_null($corporation)) {
+
+                $mail->line(
+                    sprintf('Corporation: %s', $corporation->name)
+                );
+            }
+
+            if (! is_null($character)) {
+
+                $mail->line(
+                    sprintf('Character: %s', $character->name)
+                );
+            }
+        }
+
+        return $mail;
+    }
+
+    /**
+     * @param $notifiable
+     * @return \Illuminate\Notifications\Messages\SlackMessage
+     */
+    public function toSlack($notifiable)
+    {
+        $data = yaml_parse($this->notification->text);
+
+        $message = (new SlackMessage)
+            ->content('A character has left corporation!')
+            ->from('SeAT CharLeftCorpMsg');
+
+        $character = CharacterInfo::find($data['charID']);
+
+        $corporation = CorporationInfo::find($data['corpID']);
+
+        if (! is_null($corporation) && ! is_null($character)) {
+
+            $message->attachment(function ($attachment) use ($character, $corporation) {
+
+                if (! is_null($corporation)) {
+
+                    $attachment->field(function ($field) use ($corporation) {
+
+                        $field->title('Corporation')
+                            ->content($corporation->name);
+                    });
+                }
+
+                if (! is_null($character)) {
+
+                    $attachment->field(function ($field) use ($character) {
+
+                        $field->title('Character')
+                            ->content($character->name);
+
+                    });
+                }
+            });
+
+        }
+
+        return $message;
+    }
+
+    /**
+     * @param $notifiable
+     * @return array
+     */
+    public function toArray($notifiable)
+    {
+        return yaml_parse($this->notification->text);
+    }
+}

--- a/src/Notifications/Killmail.php
+++ b/src/Notifications/Killmail.php
@@ -30,7 +30,7 @@ use Illuminate\Notifications\Notification;
  * Class Killmail.
  * @package Seat\Notifications\Notifications
  */
-class Killmail extends Notification
+class Killmail extends AbstractNotification
 {
     /**
      * @var
@@ -123,24 +123,6 @@ class Killmail extends Notification
                     ->footer('zKillboard')
                     ->footerIcon('https://zkillboard.com/img/wreck.png');
             });
-    }
-
-    /**
-     * Build a link to zKillboard using Slack message formatting.
-     *
-     * @param string $type (must be ship, character, corporation or alliance)
-     * @param int    $id   the type entity ID
-     * @param string $name the type name
-     *
-     * @return string
-     */
-    private function zKillBoardToSlackLink(string $type, int $id, string $name)
-    {
-
-        if (! in_array($type, ['ship', 'character', 'corporation', 'alliance', 'kill', 'system']))
-            return '';
-
-        return sprintf('<https://zkillboard.com/%s/%d/|%s>', $type, $id, $name);
     }
 
     /**


### PR DESCRIPTION
BREAKING CHANGES: PECL yaml extension is now required in order to parse CCP notifications
DEPENDENCIES: eveseat/notifications#28 eveseat/docker-eveseat-app#5 eveseat/docker-eveseat-worker#3 eveseat/scripts#28