### PR TITLE
ci(styleci): remove length_ordered_imports

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -3,7 +3,6 @@ preset: laravel
 risky: false
 
 enabled:
-  - alpha_ordered_imports
   - concat_with_spaces
   - no_empty_comment
 

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -11,7 +11,6 @@ disabled:
   - braces
   - phpdoc_no_package
   - concat_without_spaces
-  - length_ordered_imports
   - no_blank_lines_after_class_opening
   - no_blank_lines_after_throw
   


### PR DESCRIPTION
this directive is non longer in Laravel preset.