### PR TITLE
feat: publish alerts configuration outside package

### DIFF
--- a/src/NotificationsServiceProvider.php
+++ b/src/NotificationsServiceProvider.php
@@ -45,6 +45,9 @@ class NotificationsServiceProvider extends AbstractSeatPlugin
      */
     public function boot()
     {
+        // Register alerts
+        $this->add_alerts();
+
         $this->add_views();
 
         // Inform Laravel how to load migrations
@@ -65,6 +68,16 @@ class NotificationsServiceProvider extends AbstractSeatPlugin
     {
 
         $this->loadViewsFrom(__DIR__ . '/resources/views', 'notifications');
+    }
+
+    /**
+     * Publish alerts configuration file - so user can tweak it.
+     */
+    private function add_alerts()
+    {
+        $this->publishes([
+            __DIR__ . '/Config/notifications.alerts.php' => config_path('notifications.alerts.php'),
+        ], ['config', 'seat']);
     }
 
     /**
@@ -109,10 +122,6 @@ class NotificationsServiceProvider extends AbstractSeatPlugin
         // Package specific configuration
         $this->mergeConfigFrom(
             __DIR__ . '/Config/notifications.config.php', 'notifications.config');
-
-        // Registered alerts
-        $this->mergeConfigFrom(
-            __DIR__ . '/Config/notifications.alerts.php', 'notifications.alerts');
 
         // Add new permissions
         $this->registerPermissions(__DIR__ . '/Config/Permissions/notifications.php', 'notifications');


### PR DESCRIPTION
Configuration related to notifications will now be available inside `SEAT_PATH/config/notifications.alerts.php` and a new tag will be available (`seat`) - allowing to publish certain part of the project.

This will avoid to use `php artisan vendor:publish --all` :)

Also, people will be able to customize their notification handler easier ;)

Special thanks to @wfjsw which point me to that workflow.