### PR TITLE
Slack rate limiting

### DIFF
--- a/src/Notifications/AbstractSlackNotification.php
+++ b/src/Notifications/AbstractSlackNotification.php
@@ -8,6 +8,7 @@ use Illuminate\Queue\Middleware\RateLimitedWithRedis;
 abstract class AbstractSlackNotification extends AbstractNotification
 {
     public const RATE_LIMIT_KEY = "slack_webhook";
+    public const RATE_LIMIT = 60;
 
     public function middleware(): array
     {

--- a/src/Notifications/AbstractSlackNotification.php
+++ b/src/Notifications/AbstractSlackNotification.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Seat\Notifications\Notifications;
+
+use DateTime;
+use Illuminate\Queue\Middleware\RateLimitedWithRedis;
+
+abstract class AbstractSlackNotification extends AbstractNotification
+{
+    public const RATE_LIMIT_KEY = "slack_webhook";
+
+    public function middleware(): array
+    {
+        return [(new RateLimitedWithRedis(self::RATE_LIMIT_KEY))];
+    }
+
+    public function retryUntil(): DateTime
+    {
+        return now()->addMinutes(60);
+    }
+}

--- a/src/Notifications/AbstractSlackNotification.php
+++ b/src/Notifications/AbstractSlackNotification.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2022 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Notifications\Notifications;
 
 use DateTime;
@@ -7,12 +27,12 @@ use Illuminate\Queue\Middleware\RateLimitedWithRedis;
 
 abstract class AbstractSlackNotification extends AbstractNotification
 {
-    public const RATE_LIMIT_KEY = "slack_webhook";
+    public const RATE_LIMIT_KEY = 'slack_webhook';
     public const RATE_LIMIT = 60;
 
     public function middleware(): array
     {
-        return [(new RateLimitedWithRedis(self::RATE_LIMIT_KEY))];
+        return [new RateLimitedWithRedis(self::RATE_LIMIT_KEY)];
     }
 
     public function retryUntil(): DateTime

--- a/src/Notifications/Alliances/Slack/AllianceCapitalChanged.php
+++ b/src/Notifications/Alliances/Slack/AllianceCapitalChanged.php
@@ -27,6 +27,7 @@ use Seat\Eveapi\Models\Alliances\Alliance;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 
 /***
@@ -34,7 +35,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Alliances\Slack
  */
-class AllianceCapitalChanged extends AbstractNotification
+class AllianceCapitalChanged extends AbstractSlackNotification
 {
     use NotificationTools;
 

--- a/src/Notifications/Alliances/Slack/AllianceCapitalChanged.php
+++ b/src/Notifications/Alliances/Slack/AllianceCapitalChanged.php
@@ -26,7 +26,6 @@ use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Alliances\Alliance;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 

--- a/src/Notifications/Characters/Slack/Killmail.php
+++ b/src/Notifications/Characters/Slack/Killmail.php
@@ -25,7 +25,6 @@ namespace Seat\Notifications\Notifications\Characters\Slack;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Corporation\CorporationInfo;
 use Seat\Eveapi\Models\Killmails\KillmailDetail;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 

--- a/src/Notifications/Characters/Slack/Killmail.php
+++ b/src/Notifications/Characters/Slack/Killmail.php
@@ -26,6 +26,7 @@ use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Corporation\CorporationInfo;
 use Seat\Eveapi\Models\Killmails\KillmailDetail;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 
 /**
@@ -33,7 +34,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Characters
  */
-class Killmail extends AbstractNotification
+class Killmail extends AbstractSlackNotification
 {
     use NotificationTools;
 

--- a/src/Notifications/Characters/Slack/NewMailMessage.php
+++ b/src/Notifications/Characters/Slack/NewMailMessage.php
@@ -24,7 +24,6 @@ namespace Seat\Notifications\Notifications\Characters\Slack;
 
 use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Support\Str;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 
 /**

--- a/src/Notifications/Characters/Slack/NewMailMessage.php
+++ b/src/Notifications/Characters/Slack/NewMailMessage.php
@@ -25,13 +25,14 @@ namespace Seat\Notifications\Notifications\Characters\Slack;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Support\Str;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 
 /**
  * Class NewMailMessage.
  *
  * @package Seat\Notifications\Notifications\Characters
  */
-class NewMailMessage extends AbstractNotification
+class NewMailMessage extends AbstractSlackNotification
 {
     /**
      * @var

--- a/src/Notifications/Characters/Slack/RaffleCreated.php
+++ b/src/Notifications/Characters/Slack/RaffleCreated.php
@@ -26,7 +26,6 @@ use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 

--- a/src/Notifications/Characters/Slack/RaffleCreated.php
+++ b/src/Notifications/Characters/Slack/RaffleCreated.php
@@ -27,6 +27,7 @@ use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 
 /**
@@ -34,7 +35,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Characters\Slack
  */
-class RaffleCreated extends AbstractNotification
+class RaffleCreated extends AbstractSlackNotification
 {
     use NotificationTools;
 

--- a/src/Notifications/Characters/Slack/RaffleExpired.php
+++ b/src/Notifications/Characters/Slack/RaffleExpired.php
@@ -26,7 +26,6 @@ use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 

--- a/src/Notifications/Characters/Slack/RaffleExpired.php
+++ b/src/Notifications/Characters/Slack/RaffleExpired.php
@@ -27,6 +27,7 @@ use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 
 /**
@@ -34,7 +35,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Characters\Slack
  */
-class RaffleExpired extends AbstractNotification
+class RaffleExpired extends AbstractSlackNotification
 {
     use NotificationTools;
 

--- a/src/Notifications/Characters/Slack/RaffleFinished.php
+++ b/src/Notifications/Characters/Slack/RaffleFinished.php
@@ -26,7 +26,6 @@ use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 

--- a/src/Notifications/Characters/Slack/RaffleFinished.php
+++ b/src/Notifications/Characters/Slack/RaffleFinished.php
@@ -27,6 +27,7 @@ use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 
 /**
@@ -34,7 +35,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Characters\Slack
  */
-class RaffleFinished extends AbstractNotification
+class RaffleFinished extends AbstractSlackNotification
 {
     use NotificationTools;
 

--- a/src/Notifications/Characters/Slack/ResearchMissionAvailableMsg.php
+++ b/src/Notifications/Characters/Slack/ResearchMissionAvailableMsg.php
@@ -24,7 +24,6 @@ namespace Seat\Notifications\Notifications\Characters\Slack;
 
 use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Character\CharacterNotification;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 

--- a/src/Notifications/Characters/Slack/ResearchMissionAvailableMsg.php
+++ b/src/Notifications/Characters/Slack/ResearchMissionAvailableMsg.php
@@ -25,6 +25,7 @@ namespace Seat\Notifications\Notifications\Characters\Slack;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 
 /**
@@ -32,7 +33,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Characters\Slack
  */
-class ResearchMissionAvailableMsg extends AbstractNotification
+class ResearchMissionAvailableMsg extends AbstractSlackNotification
 {
     use NotificationTools;
 

--- a/src/Notifications/Characters/Slack/StoryLineMissionAvailableMsg.php
+++ b/src/Notifications/Characters/Slack/StoryLineMissionAvailableMsg.php
@@ -24,7 +24,6 @@ namespace Seat\Notifications\Notifications\Characters\Slack;
 
 use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Character\CharacterNotification;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 

--- a/src/Notifications/Characters/Slack/StoryLineMissionAvailableMsg.php
+++ b/src/Notifications/Characters/Slack/StoryLineMissionAvailableMsg.php
@@ -25,6 +25,7 @@ namespace Seat\Notifications\Notifications\Characters\Slack;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 
 /**
@@ -32,7 +33,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Characters\Slack
  */
-class StoryLineMissionAvailableMsg extends AbstractNotification
+class StoryLineMissionAvailableMsg extends AbstractSlackNotification
 {
     use NotificationTools;
 

--- a/src/Notifications/Corporations/Slack/BillPaidCorpAllMsg.php
+++ b/src/Notifications/Corporations/Slack/BillPaidCorpAllMsg.php
@@ -25,6 +25,7 @@ namespace Seat\Notifications\Notifications\Corporations\Slack;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 
 /**
@@ -32,7 +33,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Corporations\Slack
  */
-class BillPaidCorpAllMsg extends AbstractNotification
+class BillPaidCorpAllMsg extends AbstractSlackNotification
 {
     use NotificationTools;
 

--- a/src/Notifications/Corporations/Slack/BillPaidCorpAllMsg.php
+++ b/src/Notifications/Corporations/Slack/BillPaidCorpAllMsg.php
@@ -24,7 +24,6 @@ namespace Seat\Notifications\Notifications\Corporations\Slack;
 
 use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Character\CharacterNotification;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 

--- a/src/Notifications/Corporations/Slack/CharLeftCorpMsg.php
+++ b/src/Notifications/Corporations/Slack/CharLeftCorpMsg.php
@@ -27,13 +27,14 @@ use Seat\Eveapi\Models\Character\CharacterInfo;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Corporation\CorporationInfo;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 
 /**
  * Class CharLeftCorpMsg.
  *
  * @package Seat\Notifications\Notifications\Corporations
  */
-class CharLeftCorpMsg extends AbstractNotification
+class CharLeftCorpMsg extends AbstractSlackNotification
 {
     /**
      * @var \Seat\Eveapi\Models\Character\CharacterNotification

--- a/src/Notifications/Corporations/Slack/CharLeftCorpMsg.php
+++ b/src/Notifications/Corporations/Slack/CharLeftCorpMsg.php
@@ -26,7 +26,6 @@ use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Character\CharacterInfo;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Corporation\CorporationInfo;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 
 /**

--- a/src/Notifications/Corporations/Slack/CorpAllBillMsg.php
+++ b/src/Notifications/Corporations/Slack/CorpAllBillMsg.php
@@ -25,7 +25,6 @@ namespace Seat\Notifications\Notifications\Corporations\Slack;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Alliances\Alliance;
 use Seat\Eveapi\Models\Corporation\CorporationInfo;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 

--- a/src/Notifications/Corporations/Slack/CorpAllBillMsg.php
+++ b/src/Notifications/Corporations/Slack/CorpAllBillMsg.php
@@ -26,6 +26,7 @@ use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Alliances\Alliance;
 use Seat\Eveapi\Models\Corporation\CorporationInfo;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 
 /**
@@ -33,7 +34,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Corporations
  */
-class CorpAllBillMsg extends AbstractNotification
+class CorpAllBillMsg extends AbstractSlackNotification
 {
     use NotificationTools;
 

--- a/src/Notifications/Corporations/Slack/CorpAppNewMsg.php
+++ b/src/Notifications/Corporations/Slack/CorpAppNewMsg.php
@@ -25,7 +25,6 @@ namespace Seat\Notifications\Notifications\Corporations\Slack;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Universe\UniverseName;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 

--- a/src/Notifications/Corporations/Slack/CorpAppNewMsg.php
+++ b/src/Notifications/Corporations/Slack/CorpAppNewMsg.php
@@ -26,6 +26,7 @@ use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Universe\UniverseName;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 
 /**
@@ -33,7 +34,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Corporations\Slack
  */
-class CorpAppNewMsg extends AbstractNotification
+class CorpAppNewMsg extends AbstractSlackNotification
 {
     use NotificationTools;
 

--- a/src/Notifications/Corporations/Slack/InActiveCorpMember.php
+++ b/src/Notifications/Corporations/Slack/InActiveCorpMember.php
@@ -24,7 +24,6 @@ namespace Seat\Notifications\Notifications\Corporations\Slack;
 
 use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Corporation\CorporationMemberTracking;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 
 /**

--- a/src/Notifications/Corporations/Slack/InActiveCorpMember.php
+++ b/src/Notifications/Corporations/Slack/InActiveCorpMember.php
@@ -25,13 +25,14 @@ namespace Seat\Notifications\Notifications\Corporations\Slack;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Corporation\CorporationMemberTracking;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 
 /**
  * Class InActiveCorpMember.
  *
  * @package Seat\Notifications\Notifications\Corporations
  */
-class InActiveCorpMember extends AbstractNotification
+class InActiveCorpMember extends AbstractSlackNotification
 {
     /**
      * @var \Seat\Eveapi\Models\Corporation\CorporationMemberTracking

--- a/src/Notifications/Seat/Slack/CreatedUser.php
+++ b/src/Notifications/Seat/Slack/CreatedUser.php
@@ -24,6 +24,7 @@ namespace Seat\Notifications\Notifications\Seat\Slack;
 
 use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Web\Models\User;
 
 /**
@@ -31,7 +32,7 @@ use Seat\Web\Models\User;
  *
  * @package Seat\Notifications\Notifications\Seat
  */
-class CreatedUser extends AbstractNotification
+class CreatedUser extends AbstractSlackNotification
 {
     /**
      * @var \Seat\Web\Models\User

--- a/src/Notifications/Seat/Slack/CreatedUser.php
+++ b/src/Notifications/Seat/Slack/CreatedUser.php
@@ -23,7 +23,6 @@
 namespace Seat\Notifications\Notifications\Seat\Slack;
 
 use Illuminate\Notifications\Messages\SlackMessage;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Web\Models\User;
 

--- a/src/Notifications/Seat/Slack/DisabledToken.php
+++ b/src/Notifications/Seat/Slack/DisabledToken.php
@@ -24,7 +24,6 @@ namespace Seat\Notifications\Notifications\Seat\Slack;
 
 use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\RefreshToken;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Web\Models\User;
 

--- a/src/Notifications/Seat/Slack/DisabledToken.php
+++ b/src/Notifications/Seat/Slack/DisabledToken.php
@@ -25,6 +25,7 @@ namespace Seat\Notifications\Notifications\Seat\Slack;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\RefreshToken;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Web\Models\User;
 
 /**
@@ -32,7 +33,7 @@ use Seat\Web\Models\User;
  *
  * @package Seat\Notifications\Notifications\Seat
  */
-class DisabledToken extends AbstractNotification
+class DisabledToken extends AbstractSlackNotification
 {
     /**
      * @var \Seat\Eveapi\Models\RefreshToken

--- a/src/Notifications/Seat/Slack/EnabledToken.php
+++ b/src/Notifications/Seat/Slack/EnabledToken.php
@@ -24,7 +24,6 @@ namespace Seat\Notifications\Notifications\Seat\Slack;
 
 use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\RefreshToken;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Web\Models\User;
 

--- a/src/Notifications/Seat/Slack/EnabledToken.php
+++ b/src/Notifications/Seat/Slack/EnabledToken.php
@@ -25,6 +25,7 @@ namespace Seat\Notifications\Notifications\Seat\Slack;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\RefreshToken;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Web\Models\User;
 
 /**
@@ -32,7 +33,7 @@ use Seat\Web\Models\User;
  *
  * @package Seat\Notifications\Notifications\Seat\Slack
  */
-class EnabledToken extends AbstractNotification
+class EnabledToken extends AbstractSlackNotification
 {
     /**
      * @var \Seat\Eveapi\Models\RefreshToken

--- a/src/Notifications/Seat/Slack/SquadApplicationNotification.php
+++ b/src/Notifications/Seat/Slack/SquadApplicationNotification.php
@@ -24,6 +24,7 @@ namespace Seat\Notifications\Notifications\Seat\Slack;
 
 use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Web\Models\Squads\SquadApplication;
 
 /**
@@ -31,7 +32,7 @@ use Seat\Web\Models\Squads\SquadApplication;
  *
  * @package Seat\Notifications\Notifications\Seat
  */
-class SquadApplicationNotification extends AbstractNotification
+class SquadApplicationNotification extends AbstractSlackNotification
 {
     /**
      * @var \Seat\Web\Models\Squads\SquadApplication

--- a/src/Notifications/Seat/Slack/SquadApplicationNotification.php
+++ b/src/Notifications/Seat/Slack/SquadApplicationNotification.php
@@ -23,7 +23,6 @@
 namespace Seat\Notifications\Notifications\Seat\Slack;
 
 use Illuminate\Notifications\Messages\SlackMessage;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Web\Models\Squads\SquadApplication;
 

--- a/src/Notifications/Seat/Slack/SquadMemberNotification.php
+++ b/src/Notifications/Seat/Slack/SquadMemberNotification.php
@@ -23,7 +23,6 @@
 namespace Seat\Notifications\Notifications\Seat\Slack;
 
 use Illuminate\Notifications\Messages\SlackMessage;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Web\Models\Squads\Squad;
 use Seat\Web\Models\Squads\SquadMember;

--- a/src/Notifications/Seat/Slack/SquadMemberNotification.php
+++ b/src/Notifications/Seat/Slack/SquadMemberNotification.php
@@ -24,6 +24,7 @@ namespace Seat\Notifications\Notifications\Seat\Slack;
 
 use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Web\Models\Squads\Squad;
 use Seat\Web\Models\Squads\SquadMember;
 use Seat\Web\Models\User;
@@ -33,7 +34,7 @@ use Seat\Web\Models\User;
  *
  * @package Seat\Notifications\Notifications\Seat
  */
-class SquadMemberNotification extends AbstractNotification
+class SquadMemberNotification extends AbstractSlackNotification
 {
     /**
      * @var \Seat\Web\Models\Squads\Squad

--- a/src/Notifications/Seat/Slack/SquadMemberRemovedNotification.php
+++ b/src/Notifications/Seat/Slack/SquadMemberRemovedNotification.php
@@ -23,7 +23,6 @@
 namespace Seat\Notifications\Notifications\Seat\Slack;
 
 use Illuminate\Notifications\Messages\SlackMessage;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Web\Models\Squads\Squad;
 use Seat\Web\Models\Squads\SquadMember;

--- a/src/Notifications/Seat/Slack/SquadMemberRemovedNotification.php
+++ b/src/Notifications/Seat/Slack/SquadMemberRemovedNotification.php
@@ -24,6 +24,7 @@ namespace Seat\Notifications\Notifications\Seat\Slack;
 
 use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Web\Models\Squads\Squad;
 use Seat\Web\Models\Squads\SquadMember;
 use Seat\Web\Models\User;
@@ -33,7 +34,7 @@ use Seat\Web\Models\User;
  *
  * @package Seat\Notifications\Notifications\Seat
  */
-class SquadMemberRemovedNotification extends AbstractNotification
+class SquadMemberRemovedNotification extends AbstractSlackNotification
 {
     /**
      * @var \Seat\Web\Models\Squads\Squad

--- a/src/Notifications/Sovereignties/Slack/SovStructureDestroyed.php
+++ b/src/Notifications/Sovereignties/Slack/SovStructureDestroyed.php
@@ -26,7 +26,6 @@ use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 

--- a/src/Notifications/Sovereignties/Slack/SovStructureDestroyed.php
+++ b/src/Notifications/Sovereignties/Slack/SovStructureDestroyed.php
@@ -27,6 +27,7 @@ use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 
 /**
@@ -34,7 +35,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Sovereignties
  */
-class SovStructureDestroyed extends AbstractNotification
+class SovStructureDestroyed extends AbstractSlackNotification
 {
     use NotificationTools;
 

--- a/src/Notifications/Sovereignties/Slack/SovStructureReinforced.php
+++ b/src/Notifications/Sovereignties/Slack/SovStructureReinforced.php
@@ -25,7 +25,6 @@ namespace Seat\Notifications\Notifications\Sovereignties\Slack;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 

--- a/src/Notifications/Sovereignties/Slack/SovStructureReinforced.php
+++ b/src/Notifications/Sovereignties/Slack/SovStructureReinforced.php
@@ -26,6 +26,7 @@ use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 
 /**
@@ -33,7 +34,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Sovereignties
  */
-class SovStructureReinforced extends AbstractNotification
+class SovStructureReinforced extends AbstractSlackNotification
 {
     use NotificationTools;
 

--- a/src/Notifications/Starbases/Slack/StarbaseFuel.php
+++ b/src/Notifications/Starbases/Slack/StarbaseFuel.php
@@ -23,7 +23,6 @@
 namespace Seat\Notifications\Notifications\Starbases\Slack;
 
 use Illuminate\Notifications\Messages\SlackMessage;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 
 /**

--- a/src/Notifications/Starbases/Slack/StarbaseFuel.php
+++ b/src/Notifications/Starbases/Slack/StarbaseFuel.php
@@ -24,6 +24,7 @@ namespace Seat\Notifications\Notifications\Starbases\Slack;
 
 use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 
 /**
  * Class StarbaseFuel.
@@ -32,7 +33,7 @@ use Seat\Notifications\Notifications\AbstractNotification;
  *
  * @deprecated 4.0.0
  */
-class StarbaseFuel extends AbstractNotification
+class StarbaseFuel extends AbstractSlackNotification
 {
     /**
      * @var

--- a/src/Notifications/Starbases/Slack/StarbaseSiphons.php
+++ b/src/Notifications/Starbases/Slack/StarbaseSiphons.php
@@ -24,6 +24,7 @@ namespace Seat\Notifications\Notifications\Starbases\Slack;
 
 use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 
 /**
  * Class StarbaseSiphons.
@@ -32,7 +33,7 @@ use Seat\Notifications\Notifications\AbstractNotification;
  *
  * @deprecated 4.0.0
  */
-class StarbaseSiphons extends AbstractNotification
+class StarbaseSiphons extends AbstractSlackNotification
 {
     /**
      * @var

--- a/src/Notifications/Starbases/Slack/StarbaseSiphons.php
+++ b/src/Notifications/Starbases/Slack/StarbaseSiphons.php
@@ -23,7 +23,6 @@
 namespace Seat\Notifications\Notifications\Starbases\Slack;
 
 use Illuminate\Notifications\Messages\SlackMessage;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 
 /**

--- a/src/Notifications/Starbases/Slack/StarbaseStateChange.php
+++ b/src/Notifications/Starbases/Slack/StarbaseStateChange.php
@@ -23,7 +23,6 @@
 namespace Seat\Notifications\Notifications\Starbases\Slack;
 
 use Illuminate\Notifications\Messages\SlackMessage;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 
 /**

--- a/src/Notifications/Starbases/Slack/StarbaseStateChange.php
+++ b/src/Notifications/Starbases/Slack/StarbaseStateChange.php
@@ -24,6 +24,7 @@ namespace Seat\Notifications\Notifications\Starbases\Slack;
 
 use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 
 /**
  * Class StarbaseStateChange.
@@ -32,7 +33,7 @@ use Seat\Notifications\Notifications\AbstractNotification;
  *
  * @deprecated 4.0.0
  */
-class StarbaseStateChange extends AbstractNotification
+class StarbaseStateChange extends AbstractSlackNotification
 {
     /**
      * @var

--- a/src/Notifications/Structures/Slack/AbstractSlackMoonMiningExtraction.php
+++ b/src/Notifications/Structures/Slack/AbstractSlackMoonMiningExtraction.php
@@ -24,7 +24,6 @@ namespace Seat\Notifications\Notifications\Structures\Slack;
 
 use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Sde\InvType;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 

--- a/src/Notifications/Structures/Slack/AbstractSlackMoonMiningExtraction.php
+++ b/src/Notifications/Structures/Slack/AbstractSlackMoonMiningExtraction.php
@@ -25,6 +25,7 @@ namespace Seat\Notifications\Notifications\Structures\Slack;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 
 /**
@@ -32,7 +33,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Structures\Slack
  */
-abstract class AbstractMoonMiningExtraction extends AbstractNotification
+abstract class AbstractSlackMoonMiningExtraction extends AbstractSlackNotification
 {
     use NotificationTools;
 

--- a/src/Notifications/Structures/Slack/AllAnchoringMsg.php
+++ b/src/Notifications/Structures/Slack/AllAnchoringMsg.php
@@ -28,6 +28,7 @@ use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
 use Seat\Eveapi\Models\Universe\UniverseName;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 
 /**
@@ -35,7 +36,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Structures\Slack
  */
-class AllAnchoringMsg extends AbstractNotification
+class AllAnchoringMsg extends AbstractSlackNotification
 {
     use NotificationTools;
 

--- a/src/Notifications/Structures/Slack/AllAnchoringMsg.php
+++ b/src/Notifications/Structures/Slack/AllAnchoringMsg.php
@@ -27,7 +27,6 @@ use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
 use Seat\Eveapi\Models\Universe\UniverseName;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 

--- a/src/Notifications/Structures/Slack/MoonMiningExtractionFinished.php
+++ b/src/Notifications/Structures/Slack/MoonMiningExtractionFinished.php
@@ -32,7 +32,7 @@ use Seat\Eveapi\Models\Sde\MapDenormalize;
  *
  * @package Seat\Notifications\Notifications\Structures
  */
-class MoonMiningExtractionFinished extends AbstractMoonMiningExtraction
+class MoonMiningExtractionFinished extends AbstractSlackMoonMiningExtraction
 {
     /**
      * MoonMiningExtractionFinished constructor.

--- a/src/Notifications/Structures/Slack/MoonMiningExtractionStarted.php
+++ b/src/Notifications/Structures/Slack/MoonMiningExtractionStarted.php
@@ -32,7 +32,7 @@ use Seat\Eveapi\Models\Sde\MapDenormalize;
  *
  * @package Seat\Notifications\Notifications\Structures
  */
-class MoonMiningExtractionStarted extends AbstractMoonMiningExtraction
+class MoonMiningExtractionStarted extends AbstractSlackMoonMiningExtraction
 {
     /**
      * MoonMiningExtractionFinished constructor.

--- a/src/Notifications/Structures/Slack/OrbitalAttacked.php
+++ b/src/Notifications/Structures/Slack/OrbitalAttacked.php
@@ -27,6 +27,7 @@ use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
 use Seat\Eveapi\Models\Universe\UniverseName;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 
 /**
@@ -34,7 +35,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Structures\Slack
  */
-class OrbitalAttacked extends AbstractNotification
+class OrbitalAttacked extends AbstractSlackNotification
 {
     use NotificationTools;
 

--- a/src/Notifications/Structures/Slack/OrbitalAttacked.php
+++ b/src/Notifications/Structures/Slack/OrbitalAttacked.php
@@ -26,7 +26,6 @@ use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
 use Seat\Eveapi\Models\Universe\UniverseName;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 
@@ -80,10 +79,10 @@ class OrbitalAttacked extends AbstractSlackNotification
                             $this->zKillBoardToSlackLink(
                                 'corporation',
                                 $this->notification->text['aggressorCorpID'],
-                                (UniverseName::firstOrNew(
+                                UniverseName::firstOrNew(
                                     ['entity_id' => $this->notification->text['aggressorCorpID']],
                                     ['category' => 'corporation', 'name' => trans('web::seat.unknown')])
-                                )->name
+                                ->name
                             ));
                     })
                     ->field(function ($field) {
@@ -96,10 +95,10 @@ class OrbitalAttacked extends AbstractSlackNotification
                                 $this->zKillBoardToSlackLink(
                                     'alliance',
                                     $this->notification->text['aggressorAllianceID'],
-                                    (UniverseName::firstOrNew(
+                                    UniverseName::firstOrNew(
                                         ['entity_id' => $this->notification->text['aggressorAllianceID']],
                                         ['category' => 'alliance', 'name' => trans('web::seat.unknown')])
-                                    )->name
+                                    ->name
                                 ));
                     });
             })

--- a/src/Notifications/Structures/Slack/OwnershipTransferred.php
+++ b/src/Notifications/Structures/Slack/OwnershipTransferred.php
@@ -27,7 +27,6 @@ use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
 use Seat\Eveapi\Models\Universe\UniverseName;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 

--- a/src/Notifications/Structures/Slack/OwnershipTransferred.php
+++ b/src/Notifications/Structures/Slack/OwnershipTransferred.php
@@ -28,6 +28,7 @@ use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
 use Seat\Eveapi\Models\Universe\UniverseName;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 
 /**
@@ -35,7 +36,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Structures
  */
-class OwnershipTransferred extends AbstractNotification
+class OwnershipTransferred extends AbstractSlackNotification
 {
     use NotificationTools;
 

--- a/src/Notifications/Structures/Slack/StructureAnchoring.php
+++ b/src/Notifications/Structures/Slack/StructureAnchoring.php
@@ -26,7 +26,6 @@ use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 

--- a/src/Notifications/Structures/Slack/StructureAnchoring.php
+++ b/src/Notifications/Structures/Slack/StructureAnchoring.php
@@ -27,6 +27,7 @@ use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 
 /**
@@ -34,7 +35,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Structures\Slack
  */
-class StructureAnchoring extends AbstractNotification
+class StructureAnchoring extends AbstractSlackNotification
 {
     use NotificationTools;
 

--- a/src/Notifications/Structures/Slack/StructureDestroyed.php
+++ b/src/Notifications/Structures/Slack/StructureDestroyed.php
@@ -27,6 +27,7 @@ use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 
 /**
@@ -34,7 +35,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Structures\Slack
  */
-class StructureDestroyed extends AbstractNotification
+class StructureDestroyed extends AbstractSlackNotification
 {
     use NotificationTools;
 

--- a/src/Notifications/Structures/Slack/StructureDestroyed.php
+++ b/src/Notifications/Structures/Slack/StructureDestroyed.php
@@ -26,7 +26,6 @@ use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 

--- a/src/Notifications/Structures/Slack/StructureFuelAlert.php
+++ b/src/Notifications/Structures/Slack/StructureFuelAlert.php
@@ -26,7 +26,6 @@ use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 

--- a/src/Notifications/Structures/Slack/StructureFuelAlert.php
+++ b/src/Notifications/Structures/Slack/StructureFuelAlert.php
@@ -27,6 +27,7 @@ use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 
 /**
@@ -34,7 +35,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Structures
  */
-class StructureFuelAlert extends AbstractNotification
+class StructureFuelAlert extends AbstractSlackNotification
 {
     use NotificationTools;
 

--- a/src/Notifications/Structures/Slack/StructureLostArmor.php
+++ b/src/Notifications/Structures/Slack/StructureLostArmor.php
@@ -26,7 +26,6 @@ use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 

--- a/src/Notifications/Structures/Slack/StructureLostArmor.php
+++ b/src/Notifications/Structures/Slack/StructureLostArmor.php
@@ -27,6 +27,7 @@ use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 
 /**
@@ -34,7 +35,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Structures\Slack
  */
-class StructureLostArmor extends AbstractNotification
+class StructureLostArmor extends AbstractSlackNotification
 {
     use NotificationTools;
 

--- a/src/Notifications/Structures/Slack/StructureLostShields.php
+++ b/src/Notifications/Structures/Slack/StructureLostShields.php
@@ -26,7 +26,6 @@ use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 

--- a/src/Notifications/Structures/Slack/StructureLostShields.php
+++ b/src/Notifications/Structures/Slack/StructureLostShields.php
@@ -27,6 +27,7 @@ use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 
 /**
@@ -34,7 +35,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Structures\Slack
  */
-class StructureLostShields extends AbstractNotification
+class StructureLostShields extends AbstractSlackNotification
 {
     use NotificationTools;
 

--- a/src/Notifications/Structures/Slack/StructureServicesOffline.php
+++ b/src/Notifications/Structures/Slack/StructureServicesOffline.php
@@ -27,13 +27,14 @@ use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 
 /**
  * Class StructureServicesOffline.
  *
  * @package Seat\Notifications\Notifications\Structures
  */
-class StructureServicesOffline extends AbstractNotification
+class StructureServicesOffline extends AbstractSlackNotification
 {
     /**
      * @var \Seat\Eveapi\Models\Character\CharacterNotification

--- a/src/Notifications/Structures/Slack/StructureServicesOffline.php
+++ b/src/Notifications/Structures/Slack/StructureServicesOffline.php
@@ -26,7 +26,6 @@ use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 
 /**

--- a/src/Notifications/Structures/Slack/StructureUnanchoring.php
+++ b/src/Notifications/Structures/Slack/StructureUnanchoring.php
@@ -26,7 +26,6 @@ use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 

--- a/src/Notifications/Structures/Slack/StructureUnanchoring.php
+++ b/src/Notifications/Structures/Slack/StructureUnanchoring.php
@@ -27,6 +27,7 @@ use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 
 /**
@@ -34,7 +35,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Structures\Slack
  */
-class StructureUnanchoring extends AbstractNotification
+class StructureUnanchoring extends AbstractSlackNotification
 {
     use NotificationTools;
 

--- a/src/Notifications/Structures/Slack/StructureUnderAttack.php
+++ b/src/Notifications/Structures/Slack/StructureUnderAttack.php
@@ -27,7 +27,6 @@ use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
 use Seat\Eveapi\Models\Universe\UniverseStructure;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 

--- a/src/Notifications/Structures/Slack/StructureUnderAttack.php
+++ b/src/Notifications/Structures/Slack/StructureUnderAttack.php
@@ -28,6 +28,7 @@ use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
 use Seat\Eveapi\Models\Universe\UniverseStructure;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 
 /**
@@ -35,7 +36,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Structures
  */
-class StructureUnderAttack extends AbstractNotification
+class StructureUnderAttack extends AbstractSlackNotification
 {
     use NotificationTools;
 

--- a/src/Notifications/Structures/Slack/StructureWentHighPower.php
+++ b/src/Notifications/Structures/Slack/StructureWentHighPower.php
@@ -27,6 +27,7 @@ use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 
 /**
@@ -34,7 +35,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Structures\Slack
  */
-class StructureWentHighPower extends AbstractNotification
+class StructureWentHighPower extends AbstractSlackNotification
 {
     use NotificationTools;
 

--- a/src/Notifications/Structures/Slack/StructureWentHighPower.php
+++ b/src/Notifications/Structures/Slack/StructureWentHighPower.php
@@ -26,7 +26,6 @@ use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 

--- a/src/Notifications/Structures/Slack/StructureWentLowPower.php
+++ b/src/Notifications/Structures/Slack/StructureWentLowPower.php
@@ -26,7 +26,6 @@ use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 

--- a/src/Notifications/Structures/Slack/StructureWentLowPower.php
+++ b/src/Notifications/Structures/Slack/StructureWentLowPower.php
@@ -27,6 +27,7 @@ use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 
 /**
@@ -34,7 +35,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Structures\Slack
  */
-class StructureWentLowPower extends AbstractNotification
+class StructureWentLowPower extends AbstractSlackNotification
 {
     use NotificationTools;
 

--- a/src/Notifications/Wars/Slack/AllWarDeclaredMsg.php
+++ b/src/Notifications/Wars/Slack/AllWarDeclaredMsg.php
@@ -26,13 +26,14 @@ use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Universe\UniverseName;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 
 /**
  * Class AllWarDeclaredMsg.
  *
  * @package Seat\Notifications\Notifications\Corporations\Slack
  */
-class AllWarDeclaredMsg extends AbstractNotification
+class AllWarDeclaredMsg extends AbstractSlackNotification
 {
     /**
      * @var \Seat\Eveapi\Models\Character\CharacterNotification

--- a/src/Notifications/Wars/Slack/AllWarDeclaredMsg.php
+++ b/src/Notifications/Wars/Slack/AllWarDeclaredMsg.php
@@ -25,7 +25,6 @@ namespace Seat\Notifications\Notifications\Wars\Slack;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Universe\UniverseName;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 
 /**

--- a/src/Notifications/Wars/Slack/AllWarInvalidatedMsg.php
+++ b/src/Notifications/Wars/Slack/AllWarInvalidatedMsg.php
@@ -25,7 +25,6 @@ namespace Seat\Notifications\Notifications\Wars\Slack;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Universe\UniverseName;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 
 /***

--- a/src/Notifications/Wars/Slack/AllWarInvalidatedMsg.php
+++ b/src/Notifications/Wars/Slack/AllWarInvalidatedMsg.php
@@ -26,13 +26,14 @@ use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Universe\UniverseName;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 
 /***
  * Class AllWarInvalidatedMsg.
  *
  * @package Seat\Notifications\Notifications\Corporations\Slack
  */
-class AllWarInvalidatedMsg extends AbstractNotification
+class AllWarInvalidatedMsg extends AbstractSlackNotification
 {
     /**
      * @var \Seat\Eveapi\Models\Character\CharacterNotification

--- a/src/Notifications/Wars/Slack/AllyJoinedWarAggressorMsg.php
+++ b/src/Notifications/Wars/Slack/AllyJoinedWarAggressorMsg.php
@@ -25,7 +25,6 @@ namespace Seat\Notifications\Notifications\Wars\Slack;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Universe\UniverseName;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 

--- a/src/Notifications/Wars/Slack/AllyJoinedWarAggressorMsg.php
+++ b/src/Notifications/Wars/Slack/AllyJoinedWarAggressorMsg.php
@@ -26,6 +26,7 @@ use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Universe\UniverseName;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 
 /**
@@ -33,7 +34,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Wars\Slack
  */
-class AllyJoinedWarAggressorMsg extends AbstractNotification
+class AllyJoinedWarAggressorMsg extends AbstractSlackNotification
 {
     use NotificationTools;
 

--- a/src/Notifications/Wars/Slack/AllyJoinedWarAllyMsg.php
+++ b/src/Notifications/Wars/Slack/AllyJoinedWarAllyMsg.php
@@ -26,13 +26,14 @@ use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Universe\UniverseName;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 
 /**
  * Class AllyJoinedWarAllyMsg.
  *
  * @package Seat\Notifications\Notifications\Wars\Slack
  */
-class AllyJoinedWarAllyMsg extends AbstractNotification
+class AllyJoinedWarAllyMsg extends AbstractSlackNotification
 {
     /**
      * @var \Seat\Eveapi\Models\Character\CharacterNotification

--- a/src/Notifications/Wars/Slack/AllyJoinedWarAllyMsg.php
+++ b/src/Notifications/Wars/Slack/AllyJoinedWarAllyMsg.php
@@ -25,7 +25,6 @@ namespace Seat\Notifications\Notifications\Wars\Slack;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Universe\UniverseName;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 
 /**

--- a/src/Notifications/Wars/Slack/AllyJoinedWarDefenderMsg.php
+++ b/src/Notifications/Wars/Slack/AllyJoinedWarDefenderMsg.php
@@ -25,7 +25,6 @@ namespace Seat\Notifications\Notifications\Wars\Slack;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Universe\UniverseName;
-use Seat\Notifications\Notifications\AbstractNotification;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 
 /**

--- a/src/Notifications/Wars/Slack/AllyJoinedWarDefenderMsg.php
+++ b/src/Notifications/Wars/Slack/AllyJoinedWarDefenderMsg.php
@@ -26,13 +26,14 @@ use Illuminate\Notifications\Messages\SlackMessage;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Universe\UniverseName;
 use Seat\Notifications\Notifications\AbstractNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 
 /**
  * Class AllyJoinedWarDefenderMsg.
  *
  * @package Seat\Notifications\Notifications\Wars\Slack
  */
-class AllyJoinedWarDefenderMsg extends AbstractNotification
+class AllyJoinedWarDefenderMsg extends AbstractSlackNotification
 {
     /**
      * @var \Seat\Eveapi\Models\Character\CharacterNotification

--- a/src/NotificationsServiceProvider.php
+++ b/src/NotificationsServiceProvider.php
@@ -25,6 +25,7 @@ namespace Seat\Notifications;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Corporation\CorporationMemberTracking;
 use Seat\Eveapi\Models\Killmails\KillmailDetail;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Observers\CharacterNotificationObserver;
 use Seat\Notifications\Observers\CorporationMemberTrackingObserver;
 use Seat\Notifications\Observers\KillmailNotificationObserver;
@@ -36,6 +37,8 @@ use Seat\Services\Settings\Profile;
 use Seat\Web\Models\Squads\SquadApplication;
 use Seat\Web\Models\Squads\SquadMember;
 use Seat\Web\Models\User;
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Support\Facades\RateLimiter;
 
 /**
  * Class NotificationsServiceProvider.
@@ -68,6 +71,9 @@ class NotificationsServiceProvider extends AbstractSeatPlugin
 
         // Add events listeners
         $this->add_events();
+
+        // rate limiting for slack/discord
+        $this->add_rate_limiters();
     }
 
     /**
@@ -195,5 +201,12 @@ class NotificationsServiceProvider extends AbstractSeatPlugin
         // Notifications
         Profile::define('email_notifications', 'no');
         Profile::define('email_address', '');
+    }
+
+    private function add_rate_limiters(){
+        https://api.slack.com/docs/rate-limits
+        RateLimiter::for(AbstractSlackNotification::RATE_LIMIT_KEY, function (object $job) {
+            return Limit::perMinute(60);
+        });
     }
 }

--- a/src/NotificationsServiceProvider.php
+++ b/src/NotificationsServiceProvider.php
@@ -206,7 +206,7 @@ class NotificationsServiceProvider extends AbstractSeatPlugin
     private function add_rate_limiters(){
         https://api.slack.com/docs/rate-limits
         RateLimiter::for(AbstractSlackNotification::RATE_LIMIT_KEY, function (object $job) {
-            return Limit::perMinute(60);
+            return Limit::perMinute(AbstractSlackNotification::RATE_LIMIT);
         });
     }
 }

--- a/src/NotificationsServiceProvider.php
+++ b/src/NotificationsServiceProvider.php
@@ -22,6 +22,8 @@
 
 namespace Seat\Notifications;
 
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Support\Facades\RateLimiter;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Corporation\CorporationMemberTracking;
 use Seat\Eveapi\Models\Killmails\KillmailDetail;
@@ -37,8 +39,6 @@ use Seat\Services\Settings\Profile;
 use Seat\Web\Models\Squads\SquadApplication;
 use Seat\Web\Models\Squads\SquadMember;
 use Seat\Web\Models\User;
-use Illuminate\Cache\RateLimiting\Limit;
-use Illuminate\Support\Facades\RateLimiter;
 
 /**
  * Class NotificationsServiceProvider.
@@ -203,7 +203,7 @@ class NotificationsServiceProvider extends AbstractSeatPlugin
         Profile::define('email_address', '');
     }
 
-    private function add_rate_limiters(){
+    private function add_rate_limiters() {
         https://api.slack.com/docs/rate-limits
         RateLimiter::for(AbstractSlackNotification::RATE_LIMIT_KEY, function (object $job) {
             return Limit::perMinute(AbstractSlackNotification::RATE_LIMIT);


### PR DESCRIPTION
Slack/Discord webhooks are rate limited. When i created the contract notifications and I first tried it, I got flooded with 25 messages sent all at the same time, which kicked in discord's rate limit. This PR adds rate limiting for slack webhook calls using the laravel job rate[ limiting middleware](https://laravel.com/docs/10.x/queues#rate-limiting). 

According to the [slack documentation](https://api.slack.com/docs/rate-limits), webhooks can do up to 1 message/second, which I use as a setting. It is unclear if discord uses the same for the slack compatibility layer or if it uses it own rate limiting.

Another issue is that Laravel only allows a precision of 1 minute for rate limits, meaning that currently it send up to 60 messages at once and the waits 1 minutes(I verified this). if anyone knows a way to get second precision, please let me know.

https://github.com/eveseat/notifications/pull/74 or this needs to be updated depending on the order of merging the two