### PR TITLE
update corp leave message to allow corp or char info if either is known

### DIFF
--- a/src/Notifications/Corporations/Mail/CharLeftCorpMsg.php
+++ b/src/Notifications/Corporations/Mail/CharLeftCorpMsg.php
@@ -73,7 +73,7 @@ class CharLeftCorpMsg extends AbstractNotification
 
         $corporation = CorporationInfo::find($this->notification->text['corpID']);
 
-        if (! is_null($corporation) && ! is_null($character)) {
+        if (! is_null($corporation) || ! is_null($character)) {
 
             if (! is_null($corporation)) {
 

--- a/src/Notifications/Corporations/Slack/CharLeftCorpMsg.php
+++ b/src/Notifications/Corporations/Slack/CharLeftCorpMsg.php
@@ -73,7 +73,7 @@ class CharLeftCorpMsg extends AbstractNotification
 
         $corporation = CorporationInfo::find($this->notification->text['corpID']);
 
-        if (! is_null($corporation) && ! is_null($character)) {
+        if (! is_null($corporation) || ! is_null($character)) {
 
             $message->attachment(function ($attachment) use ($character, $corporation) {
 


### PR DESCRIPTION
Currently, if the notifcation lacks some part of the information, all of the possible information is left blank. resulting in many notifcations that only say `A character has left corporation!` This attempts to fix that so that any information the notification has, will be posted instead of nothing.