### PR TITLE
fix squad application notification dispatching

### DIFF
--- a/src/Observers/SquadApplicationObserver.php
+++ b/src/Observers/SquadApplicationObserver.php
@@ -56,7 +56,7 @@ class SquadApplicationObserver
     {
         $groups = $settings = NotificationGroup::with('alerts')
             ->whereHas('alerts', function ($query) {
-                $query->where('alert', 'squad_member');
+                $query->where('alert', 'squad_application');
             })->get();
 
         $this->dispatchNotifications('squad_application', $groups, function ($notificationClass) use ($member) {


### PR DESCRIPTION
"Squad Application" notifications are currently handled as if they are "New Squad Member" notifications while searching on which integration to send the notification on.

It looks like this was a copy&paste error. 

I think we should merge this into seat 4 too, since we have a real user on discord that is affected by this problem.