### PR TITLE
makelist of integration types dynamic

### DIFF
--- a/src/Config/notifications.integrations.php
+++ b/src/Config/notifications.integrations.php
@@ -22,18 +22,18 @@
 
 return [
     'discord' => [
-        'route'=>'seatcore::notifications.integrations.new.discord',
-        'icon'=>'fab fa-discord',
-        'label'=>'notifications::notifications.new_discord'
+        'route' => 'seatcore::notifications.integrations.new.discord',
+        'icon' => 'fab fa-discord',
+        'label' => 'notifications::notifications.new_discord',
     ],
     'slack' => [
-        'route'=>'seatcore::notifications.integrations.new.slack',
-        'icon'=>'fab fa-slack',
-        'label'=>'notifications::notifications.new_slack'
+        'route' => 'seatcore::notifications.integrations.new.slack',
+        'icon' => 'fab fa-slack',
+        'label' => 'notifications::notifications.new_slack',
     ],
     'mail' => [
-        'route'=>'seatcore::notifications.integrations.new.email',
-        'icon'=>'fas fa-envelope',
-        'label'=>'notifications::notifications.new_email'
+        'route' => 'seatcore::notifications.integrations.new.email',
+        'icon' => 'fas fa-envelope',
+        'label' => 'notifications::notifications.new_email',
     ],
 ];

--- a/src/Config/notifications.integrations.php
+++ b/src/Config/notifications.integrations.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+return [
+    'discord' => [
+        'route'=>'seatcore::notifications.integrations.new.discord',
+        'icon'=>'fab fa-discord',
+        'label'=>'notifications::notifications.new_discord'
+    ],
+    'slack' => [
+        'route'=>'seatcore::notifications.integrations.new.slack',
+        'icon'=>'fab fa-slack',
+        'label'=>'notifications::notifications.new_slack'
+    ],
+    'mail' => [
+        'route'=>'seatcore::notifications.integrations.new.email',
+        'icon'=>'fas fa-envelope',
+        'label'=>'notifications::notifications.new_email'
+    ],
+];

--- a/src/Http/Controllers/IntegrationsController.php
+++ b/src/Http/Controllers/IntegrationsController.php
@@ -42,8 +42,8 @@ class IntegrationsController extends Controller
      */
     public function getIntegrations()
     {
-
-        return view('notifications::integrations.list');
+        $integration_types = config('notifications.integrations');
+        return view('notifications::integrations.list', compact('integration_types'));
     }
 
     /**

--- a/src/Http/Controllers/IntegrationsController.php
+++ b/src/Http/Controllers/IntegrationsController.php
@@ -43,6 +43,7 @@ class IntegrationsController extends Controller
     public function getIntegrations()
     {
         $integration_types = config('notifications.integrations');
+
         return view('notifications::integrations.list', compact('integration_types'));
     }
 
@@ -125,9 +126,9 @@ class IntegrationsController extends Controller
     {
 
         Integration::create([
-            'name'     => $request->input('name'),
+            'name' => $request->input('name'),
             'settings' => ['url' => $request->input('url')],
-            'type'     => 'discord',
+            'type' => 'discord',
         ]);
 
         return redirect()->route('seatcore::notifications.integrations.list')
@@ -151,9 +152,9 @@ class IntegrationsController extends Controller
     {
 
         Integration::create([
-            'name'     => $request->input('name'),
+            'name' => $request->input('name'),
             'settings' => ['email' => $request->input('email')],
-            'type'     => 'mail',
+            'type' => 'mail',
         ]);
 
         return redirect()->route('seatcore::notifications.integrations.list')
@@ -177,9 +178,9 @@ class IntegrationsController extends Controller
     {
 
         Integration::create([
-            'name'     => $request->input('name'),
+            'name' => $request->input('name'),
             'settings' => ['url' => $request->input('url')],
-            'type'     => 'slack',
+            'type' => 'slack',
         ]);
 
         return redirect()->route('seatcore::notifications.integrations.list')

--- a/src/NotificationsServiceProvider.php
+++ b/src/NotificationsServiceProvider.php
@@ -172,6 +172,7 @@ class NotificationsServiceProvider extends AbstractSeatPlugin
         $this->publishes([
             __DIR__ . '/Config/notifications.alerts.php' => config_path('notifications.alerts.php'),
             __DIR__ . '/Config/notifications.mentions.php' => config_path('notifications.mentions.php'),
+            __DIR__ . '/Config/notifications.integrations.php' => config_path('notifications.integrations.php'),
         ], ['config', 'seat']);
     }
 

--- a/src/resources/views/integrations/list.blade.php
+++ b/src/resources/views/integrations/list.blade.php
@@ -16,20 +16,12 @@
       </p>
 
       <p>
-
-        <a href="{{ route('seatcore::notifications.integrations.new.discord') }}" class="btn btn-primary btn-block">
-          <i class="fab fa-discord"></i>
-          {{ trans('notifications::notifications.new_discord') }}
-        </a>
-        <a href="{{ route('seatcore::notifications.integrations.new.email') }}" class="btn btn-primary btn-block">
-          <i class="fas fa-envelope"></i>
-          {{ trans('notifications::notifications.new_email') }}
-        </a>
-        <a href="{{ route('seatcore::notifications.integrations.new.slack') }}" class="btn btn-primary btn-block">
-          <i class="fab fa-slack"></i>
-          {{ trans('notifications::notifications.new_slack') }}
-        </a>
-
+        @foreach($integration_types as $integration_type)
+          <a href="{{ route($integration_type['route']) }}" class="btn btn-primary btn-block">
+            <i class="{{ $integration_type['icon'] }}"></i>
+            {{ trans($integration_type['label']) }}
+          </a>
+        @endforeach
       </p>
 
     </div>


### PR DESCRIPTION
This PR allows plugins to register their own integration types so that they show up on the list of integration types when creating new integrations