### PR TITLE
Fix discord notifications

### DIFF
--- a/src/Notifications/Sovereignties/Discord/SovStructureDestroyed.php
+++ b/src/Notifications/Sovereignties/Discord/SovStructureDestroyed.php
@@ -24,7 +24,7 @@ namespace Seat\Notifications\Notifications\Sovereignties\Discord;
 
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
-use Seat\Eveapi\Models\Sde\SolarSystem;
+use Seat\Eveapi\Models\Sde\MapDenormalize;
 use Seat\Notifications\Notifications\AbstractDiscordNotification;
 use Seat\Notifications\Services\Discord\Messages\DiscordEmbed;
 use Seat\Notifications\Services\Discord\Messages\DiscordEmbedField;
@@ -68,7 +68,7 @@ class SovStructureDestroyed extends AbstractDiscordNotification
                 $embed->author('SeAT Sovereignty Health', asset('web/img/favico/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) {
-                    $system = SolarSystem::find($this->notification->text['solarSystemID']);
+                    $system = MapDenormalize::find($this->notification->text['solarSystemID']);
 
                     $field->name('System')
                         ->value(

--- a/src/Notifications/Sovereignties/Discord/SovStructureReinforced.php
+++ b/src/Notifications/Sovereignties/Discord/SovStructureReinforced.php
@@ -23,7 +23,7 @@
 namespace Seat\Notifications\Notifications\Sovereignties\Discord;
 
 use Seat\Eveapi\Models\Character\CharacterNotification;
-use Seat\Eveapi\Models\Sde\SolarSystem;
+use Seat\Eveapi\Models\Sde\MapDenormalize;
 use Seat\Notifications\Notifications\AbstractDiscordNotification;
 use Seat\Notifications\Services\Discord\Messages\DiscordEmbed;
 use Seat\Notifications\Services\Discord\Messages\DiscordEmbedField;
@@ -67,12 +67,12 @@ class SovStructureReinforced extends AbstractDiscordNotification
                 $embed->author('SeAT Sovereignty Health', asset('web/img/favico/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) {
-                    $system = SolarSystem::find($this->notification->text['solarSystemID']);
+                    $system = MapDenormalize::find($this->notification->text['solarSystemID']);
 
                     $field->name('System')
                         ->value($this->zKillBoardToDiscordLink(
                             'system',
-                            $system->itemID,
+                            $system->itemId,
                             sprintf('%s (%s)', $system->itemName, number_format($system->security, 2))));
                 });
 

--- a/src/Notifications/Structures/Traits/MoonMiningNotificationTrait.php
+++ b/src/Notifications/Structures/Traits/MoonMiningNotificationTrait.php
@@ -24,6 +24,8 @@ declare(strict_types=1);
 
 namespace Seat\Notifications\Notifications\Structures\Traits;
 
+use Seat\Eveapi\Models\Sde\InvType;
+
 trait MoonMiningNotificationTrait
 {
     const GAZ_MARKET_GROUP_ID = 2396;


### PR DESCRIPTION
- Moon Mining notifications on discord failed while the import of Seat\Eveapi\Models\Sde\InvType was missing.
- SOV notifications on discord failed while SolarSystem loaded and properties not match to MapDenormalize items used for slack notifications.