### PR TITLE
v5: Add Corporation Wardec notifications

### DIFF
--- a/src/Config/notifications.alerts.php
+++ b/src/Config/notifications.alerts.php
@@ -334,6 +334,13 @@ return [
             'discord' => \Seat\Notifications\Notifications\Structures\Discord\StructureWentLowPower::class,
         ],
     ],
+    'WarDeclared' => [
+        'label' => 'notifications::alerts.corporation_war_declared',
+        'handlers' => [
+            'discord' => \Seat\Notifications\Notifications\Wars\Discord\WarDeclaredMsg::class,
+            'slack' => \Seat\Notifications\Notifications\Wars\Slack\WarDeclaredMsg::class,
+        ],
+    ],
     'inactive_member' => [
         'label' => 'notifications::alerts.war_inactive_member',
         'handlers' => [

--- a/src/Notifications/Wars/Discord/AllWarDeclaredMsg.php
+++ b/src/Notifications/Wars/Discord/AllWarDeclaredMsg.php
@@ -73,9 +73,11 @@ class AllWarDeclaredMsg extends AbstractDiscordNotification
                         ['name' => trans('web::seat.unknown')]
                     );
 
-                    $field->name('Aggressor')
-                        ->value($this->zKillBoardToDiscordLink(
-                            $aggressor->category, $aggressor->entity_id, $aggressor->name));
+                    $field->name('Aggressor')->value(
+                        is_null($aggressor->category) ?
+                            sprintf('Unknown: %d', $aggressor->entity_id) :
+                            $this->zKillBoardToDiscordLink($aggressor->category, $aggressor->entity_id, $aggressor->name)
+                    );
                 });
 
                 $embed->field(function (DiscordEmbedField $field) {
@@ -84,9 +86,11 @@ class AllWarDeclaredMsg extends AbstractDiscordNotification
                         ['name' => trans('web::seat.unknown')]
                     );
 
-                    $field->name('Defender')
-                        ->value($this->zKillBoardToDiscordLink(
-                            $defender->category, $defender->entity_id, $defender->name));
+                    $field->name('Defender')->value(
+                        is_null($defender->category) ?
+                            sprintf('Unknown: %d', $defender->entity_id) :
+                            $this->zKillBoardToDiscordLink($defender->category, $defender->entity_id, $defender->name)
+                    );
                 });
 
                 $embed->field(function (DiscordEmbedField $field) {

--- a/src/Notifications/Wars/Discord/AllWarInvalidatedMsg.php
+++ b/src/Notifications/Wars/Discord/AllWarInvalidatedMsg.php
@@ -72,9 +72,11 @@ class AllWarInvalidatedMsg extends AbstractDiscordNotification
                         ['name' => trans('web::seat.unknown')]
                     );
 
-                    $field->name('Aggressor')
-                        ->value($this->zKillBoardToDiscordLink(
-                            $aggressor->category, $aggressor->entity_id, $aggressor->name));
+                    $field->name('Aggressor')->value(
+                        is_null($aggressor->category) ?
+                            sprintf('Unknown: %d', $aggressor->entity_id) :
+                            $this->zKillBoardToDiscordLink($aggressor->category, $aggressor->entity_id, $aggressor->name)
+                    );
                 });
 
                 $embed->field(function (DiscordEmbedField $field) {
@@ -83,9 +85,11 @@ class AllWarInvalidatedMsg extends AbstractDiscordNotification
                         ['name' => trans('web::seat.unknown')]
                     );
 
-                    $field->name('Defender')
-                        ->value($this->zKillBoardToDiscordLink(
-                            $defender->category, $defender->entity_id, $defender->name));
+                    $field->name('Defender')->value(
+                        is_null($defender->category) ?
+                            sprintf('Unknown: %d', $defender->entity_id) :
+                            $this->zKillBoardToDiscordLink($defender->category, $defender->entity_id, $defender->name)
+                    );
                 });
 
                 $embed->field(function (DiscordEmbedField $field) {

--- a/src/Notifications/Wars/Discord/AllyJoinedWarAggressorMsg.php
+++ b/src/Notifications/Wars/Discord/AllyJoinedWarAggressorMsg.php
@@ -72,9 +72,11 @@ class AllyJoinedWarAggressorMsg extends AbstractDiscordNotification
                         ['name' => trans('web::seat.unknown')]
                     );
 
-                    $field->name('Aggressor')
-                        ->value($this->zKillBoardToDiscordLink(
-                            $aggressor->category, $aggressor->entity_id, $aggressor->name));
+                    $field->name('Aggressor')->value(
+                        is_null($aggressor->category) ?
+                            sprintf('Unknown: %d', $aggressor->entity_id) :
+                            $this->zKillBoardToDiscordLink($aggressor->category, $aggressor->entity_id, $aggressor->name)
+                    );
                 });
 
                 $embed->field(function (DiscordEmbedField $field) {
@@ -83,9 +85,11 @@ class AllyJoinedWarAggressorMsg extends AbstractDiscordNotification
                         ['name' => trans('web::seat.unknown')]
                     );
 
-                    $field->name('Defender')
-                        ->value($this->zKillBoardToDiscordLink(
-                            $defender->category, $defender->entity_id, $defender->name));
+                    $field->name('Defender')->value(
+                        is_null($defender->category) ?
+                            sprintf('Unknown: %d', $defender->entity_id) :
+                            $this->zKillBoardToDiscordLink($defender->category, $defender->entity_id, $defender->name)
+                    );
                 });
 
                 $embed->field(function (DiscordEmbedField $field) {

--- a/src/Notifications/Wars/Discord/AllyJoinedWarAllyMsg.php
+++ b/src/Notifications/Wars/Discord/AllyJoinedWarAllyMsg.php
@@ -72,9 +72,11 @@ class AllyJoinedWarAllyMsg extends AbstractDiscordNotification
                         ['name' => trans('web::seat.unknown')]
                     );
 
-                    $field->name('Aggressor')
-                        ->value($this->zKillBoardToDiscordLink(
-                            $aggressor->category, $aggressor->entity_id, $aggressor->name));
+                    $field->name('Aggressor')->value(
+                        is_null($aggressor->category) ?
+                            sprintf('Unknown: %d', $aggressor->entity_id) :
+                            $this->zKillBoardToDiscordLink($aggressor->category, $aggressor->entity_id, $aggressor->name)
+                    );
                 });
 
                 $embed->field(function (DiscordEmbedField $field) {
@@ -83,9 +85,11 @@ class AllyJoinedWarAllyMsg extends AbstractDiscordNotification
                         ['name' => trans('web::seat.unknown')]
                     );
 
-                    $field->name('Defender')
-                        ->value($this->zKillBoardToDiscordLink(
-                            $defender->category, $defender->entity_id, $defender->name));
+                    $field->name('Defender')->value(
+                        is_null($defender->category) ?
+                            sprintf('Unknown: %d', $defender->entity_id) :
+                            $this->zKillBoardToDiscordLink($defender->category, $defender->entity_id, $defender->name)
+                    );
                 });
 
                 $embed->field(function (DiscordEmbedField $field) {

--- a/src/Notifications/Wars/Discord/AllyJoinedWarDefenderMsg.php
+++ b/src/Notifications/Wars/Discord/AllyJoinedWarDefenderMsg.php
@@ -72,9 +72,11 @@ class AllyJoinedWarDefenderMsg extends AbstractDiscordNotification
                         ['name' => trans('web::seat.unknown')]
                     );
 
-                    $field->name('Aggressor')
-                        ->value($this->zKillBoardToDiscordLink(
-                            $aggressor->category, $aggressor->entity_id, $aggressor->name));
+                    $field->name('Aggressor')->value(
+                        is_null($aggressor->category) ?
+                            sprintf('Unknown: %d', $aggressor->entity_id) :
+                            $this->zKillBoardToDiscordLink($aggressor->category, $aggressor->entity_id, $aggressor->name)
+                    );
                 });
 
                 $embed->field(function (DiscordEmbedField $field) {
@@ -83,9 +85,11 @@ class AllyJoinedWarDefenderMsg extends AbstractDiscordNotification
                         ['name' => trans('web::seat.unknown')]
                     );
 
-                    $field->name('Defender')
-                        ->value($this->zKillBoardToDiscordLink(
-                            $defender->category, $defender->entity_id, $defender->name));
+                    $field->name('Defender')->value(
+                        is_null($defender->category) ?
+                            sprintf('Unknown: %d', $defender->entity_id) :
+                            $this->zKillBoardToDiscordLink($defender->category, $defender->entity_id, $defender->name)
+                    );
                 });
 
                 $embed->field(function (DiscordEmbedField $field) {

--- a/src/Notifications/Wars/Discord/WarDeclaredMsg.php
+++ b/src/Notifications/Wars/Discord/WarDeclaredMsg.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Notifications\Notifications\Wars\Discord;
+
+use Seat\Eveapi\Models\Character\CharacterNotification;
+use Seat\Eveapi\Models\Universe\UniverseName;
+use Seat\Notifications\Notifications\AbstractDiscordNotification;
+use Seat\Notifications\Services\Discord\Messages\DiscordEmbed;
+use Seat\Notifications\Services\Discord\Messages\DiscordEmbedField;
+use Seat\Notifications\Services\Discord\Messages\DiscordMessage;
+use Seat\Notifications\Traits\NotificationTools;
+
+/**
+ * Class WarDeclaredMsg.
+ *
+ * @package Seat\Notifications\Notifications\Wars\Discord
+ */
+class WarDeclaredMsg extends AbstractDiscordNotification
+{
+    use NotificationTools;
+
+    /**
+     * @var \Seat\Eveapi\Models\Character\CharacterNotification
+     */
+    private $notification;
+
+    /**
+     * Constructor.
+     *
+     * @param  \Seat\Eveapi\Models\Character\CharacterNotification  $notification
+     */
+    public function __construct(CharacterNotification $notification)
+    {
+        $this->notification = $notification;
+    }
+
+    /**
+     * @param  DiscordMessage  $message
+     * @param  $notifiable
+     */
+    public function populateMessage(DiscordMessage $message, $notifiable)
+    {
+        logger()->debug('[DiscordMessage] Init.', $this->notification->toArray());
+
+        $message
+            ->content('A new War has been declared ! :boom:')
+            ->embed(function (DiscordEmbed $embed) {
+                $embed->timestamp($this->notification->timestamp);
+                $embed->color($this->notification->text['hostileState'] ? 13632027 : 16098851);
+                $embed->author('SeAT War Observer', asset('web/img/favico/apple-icon-180x180.png'));
+
+                $embed->field(function (DiscordEmbedField $field) {
+                    $aggressor = UniverseName::firstOrNew(
+                        ['entity_id' => $this->notification->text['declaredByID']],
+                        ['name' => trans('web::seat.unknown')]
+                    );
+
+                    $field->name('Aggressor')->value(
+                        is_null($aggressor->category) ?
+                            sprintf('Unknown: %d', $aggressor->entity_id) :
+                            $this->zKillBoardToDiscordLink($aggressor->category, $aggressor->entity_id, $aggressor->name)
+                    );
+                });
+
+                $embed->field(function (DiscordEmbedField $field) {
+                    $defender = UniverseName::firstOrNew(
+                        ['entity_id' => $this->notification->text['againstID']],
+                        ['name' => trans('web::seat.unknown')]
+                    );
+
+                    $field->name('Defender')->value(
+                        is_null($defender->category) ?
+                            sprintf('Unknown: %d', $defender->entity_id) :
+                            $this->zKillBoardToDiscordLink($defender->category, $defender->entity_id, $defender->name)
+                    );
+                });
+
+                $embed->field(function (DiscordEmbedField $field) {
+                    $field->name('Start In')
+                        ->value(sprintf('%d hours', $this->notification->text['delayHours']));
+                });
+            });
+    }
+}

--- a/src/Notifications/Wars/Slack/WarDeclaredMsg.php
+++ b/src/Notifications/Wars/Slack/WarDeclaredMsg.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Notifications\Notifications\Wars\Slack;
+
+use Illuminate\Notifications\Messages\SlackMessage;
+use Seat\Eveapi\Models\Character\CharacterNotification;
+use Seat\Eveapi\Models\Universe\UniverseName;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
+
+/**
+ * Class WarDeclaredMsg.
+ *
+ * @package Seat\Notifications\Notifications\Corporations\Slack
+ */
+class WarDeclaredMsg extends AbstractSlackNotification
+{
+    /**
+     * @var \Seat\Eveapi\Models\Character\CharacterNotification
+     */
+    private $notification;
+
+    /**
+     * WarDeclaredMsg constructor.
+     *
+     * @param  \Seat\Eveapi\Models\Character\CharacterNotification  $notification
+     */
+    public function __construct(CharacterNotification $notification)
+    {
+        $this->notification = $notification;
+    }
+
+    /**
+     * @param  $notifiable
+     * @return \Illuminate\Notifications\Messages\SlackMessage
+     */
+    public function toSlack($notifiable)
+    {
+        $message = (new SlackMessage())
+            ->from('SeAT War Observer')
+            ->content('A new War has been declared !')
+            ->attachment(function ($attachment) {
+                $attachment
+                    ->field(function ($field) {
+                        $entity = UniverseName::firstOrNew(
+                            ['entity_id' => $this->notification->text['declaredByID']],
+                            ['name' => trans('web::seat.unknown')]
+                        );
+
+                        $field->title('Aggressor')
+                            ->content($entity->name);
+                    })
+                    ->field(function ($field) {
+                        $entity = UniverseName::firstOrNew(
+                            ['entity_id' => $this->notification->text['againstID']],
+                            ['name' => trans('web::seat.unknown')]
+                        );
+
+                        $field->title('Defender')
+                            ->content($entity->name);
+                    });
+            })
+            ->attachment(function ($attachment) {
+                $attachment->field(function ($field) {
+                    $field->title('Start in')
+                        ->content(sprintf('%d hours', $this->notification->text['delayHours']));
+                });
+            });
+
+        ($this->notification->text['hostileState']) ?
+            $message->error() : $message->warning();
+
+        return $message;
+    }
+}

--- a/src/resources/lang/en/alerts.php
+++ b/src/resources/lang/en/alerts.php
@@ -43,6 +43,7 @@ return [
     'character_left_corporation' => 'Corporation Leaving Character',
     'corporation_alliance_bill' => 'New Alliance Bill',
     'corporation_application_new' => 'New Corporation Application',
+    'corporation_war_declared' => 'Corporation War Declared',
     'entosis_capture_started' => 'Entosis Capture Started',
     'moon_mining_extraction_finished' => 'MM Finished Extractions',
     'moon_mining_extraction_started' => 'MM Started Extractions',


### PR DESCRIPTION
V5 re-implementation of https://github.com/eveseat/notifications/pull/91

- Adds notification for the WarDeclared notification which is sent to Corporations when a war declaration is made.
- Fixes an issue that the notification fails if the attacker or defender does not exist in UniverseName yet.

If the UniverseName is not yet populated then the `category` property is null. Which makes the call to zKillBoardToDiscordLink fail with the error
```
zKillBoardToDiscordLink(): Argument #1 ($type) must be of type string, null given
```