### PR TITLE
Fix StructureFuelAlert color

### DIFF
--- a/src/Notifications/Structures/Discord/StructureFuelAlert.php
+++ b/src/Notifications/Structures/Discord/StructureFuelAlert.php
@@ -87,7 +87,7 @@ class StructureFuelAlert extends AbstractDiscordNotification
                     });
                 }
 
-                $embed->color('#439fe0');
+                $embed->color(DiscordMessage::INFO);
             });
     }
 }


### PR DESCRIPTION
Fix for the following error reported on discord:
```
TypeError: Seat\Notifications\Services\Discord\Messages\DiscordEmbed::color(): Argument #1 ($color) must be of type int, string given, called in /var/www/seat/vendor/eveseat/notifications/src/Notifications/Structures/Discord/StructureFuelAlert.php on line 90 and defined in /var/www/seat/vendor/eveseat/notifications/src/Services/Discord/Messages/DiscordEmbed.php:161
Stack trace:
#0 /var/www/seat/vendor/eveseat/notifications/src/Notifications/Structures/Discord/StructureFuelAlert.php(90): Seat\Notifications\Services\Discord\Messages\DiscordEmbed->color('#439fe0')
#1 /var/www/seat/vendor/eveseat/notifications/src/Services/Discord/Messages/DiscordMessage.php(226): Seat\Notifications\Notifications\Structures\Discord\StructureFuelAlert->Seat\Notifications\Notifications\Structures\Discord\{closure}(Object(Seat\Notifications\Services\Discord\Messages\DiscordEmbed))
#2 /var/www/seat/vendor/eveseat/notifications/src/Notifications/Structures/Discord/StructureFuelAlert.php(79): Seat\Notifications\Services\Discord\Messages\DiscordMessage->embed(Object(Closure))
```