### PR TITLE
Discord notifications update for Structures. 

### DIFF
--- a/src/Notifications/Structures/Discord/StructureFuelAlert.php
+++ b/src/Notifications/Structures/Discord/StructureFuelAlert.php
@@ -71,8 +71,14 @@ class StructureFuelAlert extends AbstractDiscordNotification
 
                 $embed->field(function (DiscordEmbedField $field) {
                     $type = InvType::find($this->notification->text['structureShowInfoData'][1]);
+                   
+                    $title = 'Structure';
 
-                    $field->name('Structure')
+                    if (! is_null($structure)) {
+                        $title = $structure->name;
+                    }
+
+                    $field->name($title)
                         ->value($type->typeName);
                 });
             })

--- a/src/Notifications/Structures/Discord/StructureLostArmor.php
+++ b/src/Notifications/Structures/Discord/StructureLostArmor.php
@@ -73,13 +73,16 @@ class StructureLostArmor extends AbstractDiscordNotification
                 });
 
                 $embed->field(function (DiscordEmbedField $field) {
-                    $type = InvType::firstOrNew(
-                        ['typeID' => $this->notification->text['structureTypeID']],
-                        ['typeName' => trans('web::seat.unknown')]
-                    );
+                    $type = InvType::find($this->notification->text['structureShowInfoData'][1]);
+                   
+                    $title = 'Structure';
 
-                    $field->name('Structure')
-                        ->value($this->zKillBoardToDiscordLink('ship', $type->typeID, $type->typeName));
+                    if (! is_null($structure)) {
+                        $title = $structure->name;
+                    }
+
+                    $field->name($title)
+                        ->value($type->typeName);
                 });
             })
             ->warning();

--- a/src/Notifications/Structures/Discord/StructureLostShields.php
+++ b/src/Notifications/Structures/Discord/StructureLostShields.php
@@ -73,13 +73,16 @@ class StructureLostShields extends AbstractDiscordNotification
                 });
 
                 $embed->field(function (DiscordEmbedField $field) {
-                    $type = InvType::firstOrNew(
-                        ['typeID' => $this->notification->text['structureTypeID']],
-                        ['typeName' => trans('web::seat.unknown')]
-                    );
+                    $type = InvType::find($this->notification->text['structureShowInfoData'][1]);
+                   
+                    $title = 'Structure';
 
-                    $field->name('Structure')
-                        ->value($this->zKillBoardToDiscordLink('ship', $type->typeID, $type->typeName));
+                    if (! is_null($structure)) {
+                        $title = $structure->name;
+                    }
+
+                    $field->name($title)
+                        ->value($type->typeName);
                 });
             })
             ->warning();

--- a/src/Notifications/Structures/Discord/StructureWentHighPower.php
+++ b/src/Notifications/Structures/Discord/StructureWentHighPower.php
@@ -74,13 +74,16 @@ class StructureWentHighPower extends AbstractDiscordNotification
                 });
 
                 $embed->field(function (DiscordEmbedField $field) {
-                    $type = InvType::firstOrNew(
-                        ['typeID' => $this->notification->text['structureTypeID']],
-                        ['typeName' => trans('web::seat.unknown')]
-                    );
+                    $type = InvType::find($this->notification->text['structureShowInfoData'][1]);
+                   
+                    $title = 'Structure';
 
-                    $field->name('Structure')
-                        ->value($this->zKillBoardToDiscordLink('ship', $type->typeID, $type->typeName));
+                    if (! is_null($structure)) {
+                        $title = $structure->name;
+                    }
+
+                    $field->name($title)
+                        ->value($type->typeName);
                 });
             });
     }

--- a/src/Notifications/Structures/Discord/StructureWentLowPower.php
+++ b/src/Notifications/Structures/Discord/StructureWentLowPower.php
@@ -73,13 +73,16 @@ class StructureWentLowPower extends AbstractDiscordNotification
                 });
 
                 $embed->field(function (DiscordEmbedField $field) {
-                    $type = InvType::firstOrNew(
-                        ['typeID' => $this->notification->text['structureTypeID']],
-                        ['typeName' => trans('web::seat.unknown')]
-                    );
+                    $type = InvType::find($this->notification->text['structureShowInfoData'][1]);
+                   
+                    $title = 'Structure';
 
-                    $field->name('Structure')
-                        ->value($this->zKillBoardToDiscordLink('ship', $type->typeID, $type->typeName));
+                    if (! is_null($structure)) {
+                        $title = $structure->name;
+                    }
+
+                    $field->name($title)
+                        ->value($type->typeName);
                 });
             });
     }


### PR DESCRIPTION
The old notification was giving only structure type information [and in some cases with zkill link to a structure type] not the actual name. Replaced that so it will say the name of the structure and the type of the structure at the same time. More useful if you have 30 structures in the same system.
