### PR TITLE
Structure Notification Samples

### DIFF
--- a/docs/notification-text-samples.md
+++ b/docs/notification-text-samples.md
@@ -1,0 +1,19 @@
+# Notification Text Samples
+When working on notifications, it is, like with any code, important to test your changes.
+This poses some unique challenges with the `notifications` packages: Some notifications
+like `StructureDestroyed` are hard to generate in EVE for obvious reasons, meaning it is 
+difficult to test them. Therefore, we decided to create a collection of such difficult
+notifications that can be imported for testing.
+
+EVE notification in SeAT are stored in the `character_notifications` table. Most of the columns
+of this table are easy to fake for testing, except for `type` and `text`, which aren't documented
+by CCP.
+
+The `notification-text-samples` directory contains a file for some notification types, with the
+filename being the `type` column. In some cases, a comment is added with a `-`, e.g. 
+`StructureUnderAttack-Hull.yaml`. In that case, only `StructureUnderAttack` is the type and
+`Hull` is just a comment.
+
+The content of such a file is the value of the `text` field. The data is randomized on request
+of the people that helped to collect the dataset, so while it references for example valid 
+structure ids, the solar system id might not match the actual system of the structure.

--- a/docs/notification-text-samples/StructureDestroyed.yaml
+++ b/docs/notification-text-samples/StructureDestroyed.yaml
@@ -1,0 +1,13 @@
+isAbandoned: false
+ownerCorpLinkData:
+  - showinfo
+  - 2
+  - 1000001
+ownerCorpName: Doomheim
+solarsystemID: 31000671
+structureID: &id001 1032717532381
+structureShowInfoData:
+  - showinfo
+  - 35835
+  - *id001
+structureTypeID: 35835

--- a/docs/notification-text-samples/StructureLostShields.yaml
+++ b/docs/notification-text-samples/StructureLostShields.yaml
@@ -1,0 +1,10 @@
+solarsystemID: 31000671
+structureID: &id001 1032717532381
+structureShowInfoData:
+  - showinfo
+  - 35835
+  - *id001
+structureTypeID: 35835
+timeLeft: 3252541831648
+timestamp: 123688745190000000
+vulnerableTime: 9000000000

--- a/docs/notification-text-samples/StructureUnderAttack-Armor.yaml
+++ b/docs/notification-text-samples/StructureUnderAttack-Armor.yaml
@@ -1,0 +1,22 @@
+allianceID: 99011162
+allianceLinkData:
+  - showinfo
+  - 16159
+  - 99011162
+allianceName: Test Alliance Please Ignore
+armorPercentage: 99.97752473143959
+charID: 2120512110
+corpLinkData:
+  - showinfo
+  - 2
+  - 1000001
+corpName: Doomheim
+hullPercentage: 100.0
+shieldPercentage: 1.4270966304931494e-10
+solarsystemID: 31000671
+structureID: &id001 1032717532381
+structureShowInfoData:
+  - showinfo
+  - 35835
+  - *id001
+structureTypeID: 35835

--- a/docs/notification-text-samples/StructureUnderAttack-Hull.yaml
+++ b/docs/notification-text-samples/StructureUnderAttack-Hull.yaml
@@ -1,0 +1,22 @@
+allianceID: 99011162
+allianceLinkData:
+  - showinfo
+  - 16159
+  - 99011162
+allianceName: Test Alliance Please Ignore
+armorPercentage: -340.00000000000006
+charID: 2120512110
+corpLinkData:
+  - showinfo
+  - 2
+  - 1000001
+corpName: Doomheim
+hullPercentage: 99.05702928542462
+shieldPercentage: 4.833641826923347e-15
+solarsystemID: 31000671
+structureID: &id001 1032717532381
+structureShowInfoData:
+  - showinfo
+  - 35835
+  - *id001
+structureTypeID: 35835

--- a/docs/notification-text-samples/StructureUnderAttack-Shields.yaml
+++ b/docs/notification-text-samples/StructureUnderAttack-Shields.yaml
@@ -1,0 +1,22 @@
+allianceID: 99011162
+allianceLinkData:
+  - showinfo
+  - 16159
+  - 99011162
+allianceName: Test Alliance Please Ignore
+armorPercentage: 100.0
+charID: 2120512110
+corpLinkData:
+  - showinfo
+  - 2
+  - 1000001
+corpName: Doomheim
+hullPercentage: 100.0
+shieldPercentage: 94.8777165028905
+solarsystemID: 31000671
+structureID: &id001 1032717532381
+structureShowInfoData:
+  - showinfo
+  - 35835
+  - *id001
+structureTypeID: 35835

--- a/docs/notification-text-samples/StructureWentLowPower.yaml
+++ b/docs/notification-text-samples/StructureWentLowPower.yaml
@@ -1,0 +1,7 @@
+solarsystemID: 31000671
+structureID: &id001 1032717532381
+structureShowInfoData:
+  - showinfo
+  - 35835
+  - *id001
+structureTypeID: 35835


### PR DESCRIPTION
When working on notifications, it is, like with any code, important to test your changes.
This poses some unique challenges with the `notifications` packages: Some notifications
like `StructureDestroyed` are hard to generate in EVE for obvious reasons, meaning it is 
difficult to test them. This PR adds a few samples for structure notifications.

The data is randomized.