### PR TITLE
feature: suppress discord pings in notifications

### DIFF
--- a/src/Notifications/AbstractDiscordNotification.php
+++ b/src/Notifications/AbstractDiscordNotification.php
@@ -56,9 +56,11 @@ abstract class AbstractDiscordNotification extends AbstractNotification
     {
         $message = new DiscordMessage();
 
-        foreach ($this->getMentions() as $mention){
-            [$class,$method] = explode('@', $mention->getType()->message_adapter, 2);
-            $class::$method($message, $mention->data);
+        if(! $this->suppressMentions()) {
+            foreach ($this->getMentions() as $mention) {
+                [$class, $method] = explode('@', $mention->getType()->message_adapter, 2);
+                $class::$method($message, $mention->data);
+            }
         }
 
         $this->populateMessage($message, $notifiable);
@@ -73,4 +75,14 @@ abstract class AbstractDiscordNotification extends AbstractNotification
      * @param  $notifiable
      * */
     abstract protected function populateMessage(DiscordMessage $message, $notifiable);
+
+    /**
+     * Whether to suppress discord pings for this notification.
+     *
+     * @return bool
+     */
+    protected function suppressMentions(): bool
+    {
+        return false;
+    }
 }


### PR DESCRIPTION
I was asked if it is possible to make discord pings for alliance-industry optional. Since alliance-industry uses the core notifications package for pings, I need to expose an API to do that for plugins.