### PR TITLE
fix: validate webhook URLs against allowlist to prevent SSRF

### DIFF
--- a/src/Http/Validation/DiscordIntegration.php
+++ b/src/Http/Validation/DiscordIntegration.php
@@ -53,7 +53,19 @@ class DiscordIntegration extends FormRequest
         return [
 
             'name' => 'required|max:255|unique:integrations,name',
-            'url' => 'required|url',
+            'url' => ['required', 'url', function ($attribute, $value, $fail) {
+                $host = parse_url($value, PHP_URL_HOST);
+                $allowedHosts = [
+                    'discord.com',
+                    'discordapp.com',
+                ];
+                $isAllowed = collect($allowedHosts)->contains(function ($allowed) use ($host) {
+                    return $host === $allowed || str_ends_with($host, '.' . $allowed);
+                });
+                if (! $isAllowed) {
+                    $fail('The webhook URL must be a valid Discord webhook URL (discord.com or discordapp.com).');
+                }
+            }],
         ];
     }
 }

--- a/src/Http/Validation/SlackIntegration.php
+++ b/src/Http/Validation/SlackIntegration.php
@@ -53,7 +53,19 @@ class SlackIntegration extends FormRequest
         return [
 
             'name' => 'required|max:255|unique:integrations,name',
-            'url' => 'required|url',
+            'url' => ['required', 'url', function ($attribute, $value, $fail) {
+                $host = parse_url($value, PHP_URL_HOST);
+                $allowedHosts = [
+                    'hooks.slack.com',
+                    'slack.com',
+                ];
+                $isAllowed = collect($allowedHosts)->contains(function ($allowed) use ($host) {
+                    return $host === $allowed || str_ends_with($host, '.' . $allowed);
+                });
+                if (! $isAllowed) {
+                    $fail('The webhook URL must be a valid Slack webhook URL (hooks.slack.com or slack.com).');
+                }
+            }],
         ];
     }
 }


### PR DESCRIPTION
## Security Fix: Server-Side Request Forgery (SSRF) via Webhook URLs

### Vulnerability

The Discord and Slack integration forms accepted any syntactically valid URL as a webhook endpoint, with no restriction on the destination host:

```php
'url' => 'required|url'
```

### Impact

An authenticated user with the `notifications.setup` permission could configure a webhook pointing to internal network resources. When a notification is triggered (or the "Test" button is clicked), the SeAT server makes an outbound HTTP request to the attacker-controlled URL from inside the server's network.

This allows:
- **Internal network scanning**: probing services like Redis (`:6379`), MySQL (`:3306`), internal APIs
- **Cloud metadata exfiltration**: on AWS/GCP/Azure, fetching `http://169.254.169.254/latest/meta-data/` exposes instance credentials and configuration
- **Internal service interaction**: sending arbitrary HTTP requests to services that trust traffic from the application server

### Fix

Added domain allowlist validation for webhook URLs. Discord webhooks must use `discord.com` or `discordapp.com`, and Slack webhooks must use `hooks.slack.com` or `slack.com`. URLs pointing to any other host are rejected at the validation layer before any HTTP request is made.

### References

- [OWASP: Server-Side Request Forgery (SSRF)](https://owasp.org/www-community/attacks/Server_Side_Request_Forgery)
- [OWASP: SSRF Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html)
- [CWE-918: Server-Side Request Forgery (SSRF)](https://cwe.mitre.org/data/definitions/918.html)
- [HackerOne: SSRF via webhook (common pattern)](https://www.hackerone.com/blog/how-to-server-side-request-forgery-ssrf)