### PR TITLE
Lots of notification updates

### DIFF
--- a/docs/notification-text-samples/OrbitalReinforced.yaml
+++ b/docs/notification-text-samples/OrbitalReinforced.yaml
@@ -1,0 +1,8 @@
+aggressorAllianceID: null
+aggressorCorpID: 98749616
+aggressorID: 2117204642
+planetID: 40121487
+planetTypeID: 2017
+reinforceExitTime: 134259524910000000
+solarSystemID: 30001901
+typeID: 2233

--- a/docs/notification-text-samples/SkyhookLostShields.yaml
+++ b/docs/notification-text-samples/SkyhookLostShields.yaml
@@ -1,0 +1,15 @@
+itemID: &id001 1052265367878
+planetID: 40303956
+planetShowInfoData:
+  - showinfo
+  - 11
+  - 40303956
+skyhookShowInfoData:
+  - showinfo
+  - 81080
+  - *id001
+solarsystemID: 30004801
+timeLeft: 2086699818101
+timestamp: 134258793670000000
+typeID: 81080
+vulnerableTime: 9000000000

--- a/docs/notification-text-samples/SkyhookUnderAttack.yaml
+++ b/docs/notification-text-samples/SkyhookUnderAttack.yaml
@@ -1,0 +1,28 @@
+allianceID: 99015056
+allianceLinkData:
+  - showinfo
+  - 16159
+  - 99015056
+allianceName: Calculated Disorder
+armorPercentage: 100.0
+charID: 1786133582
+corpLinkData:
+  - showinfo
+  - 2
+  - 98328437
+corpName: Applied Anarchy
+hullPercentage: 100.0
+isActive: true
+itemID: &id001 1047299233673
+planetID: 40303639
+planetShowInfoData:
+  - showinfo
+  - 2016
+  - 40303639
+shieldPercentage: 94.96017719205628
+skyhookShowInfoData:
+  - showinfo
+  - 81080
+  - *id001
+solarsystemID: 30004796
+typeID: 81080

--- a/src/Config/notifications.alerts.php
+++ b/src/Config/notifications.alerts.php
@@ -195,6 +195,13 @@ return [
             'discord' => \Seat\Notifications\Notifications\Structures\Discord\OrbitalAttacked::class,
         ],
     ],
+    'OrbitalReinforced' => [
+        'label' => 'notifications::alerts.orbital_reinforced',
+        'handlers' => [
+            'slack' => \Seat\Notifications\Notifications\Structures\Slack\OrbitalReinforced::class,
+            'discord' => \Seat\Notifications\Notifications\Structures\Discord\OrbitalReinforced::class,
+        ],
+    ],
     'OwnershipTransferred' => [
         'label' => 'notifications::alerts.ownership_transferred',
         'handlers' => [

--- a/src/Config/notifications.alerts.php
+++ b/src/Config/notifications.alerts.php
@@ -233,37 +233,37 @@ return [
     'SkyhookDeployed' => [
         'label' => 'notifications::alerts.skyhook_deployed',
         'handlers' => [
-            'discord' => \Seat\Notifications\Notifications\Structures\Discord\StructureAnchoring::class,
-            'slack' => \Seat\Notifications\Notifications\Structures\Slack\StructureAnchoring::class,
+            'discord' => \Seat\Notifications\Notifications\Structures\Discord\SkyhookDeployed::class,
+            'slack' => \Seat\Notifications\Notifications\Structures\Slack\SkyhookDeployed::class,
         ],
     ],
     'SkyhookDestroyed' => [
         'label' => 'notifications::alerts.skyhook_destroyed',
         'handlers' => [
-            'discord' => \Seat\Notifications\Notifications\Structures\Discord\StructureDestroyed::class,
-            'slack' => \Seat\Notifications\Notifications\Structures\Slack\StructureDestroyed::class,
+            'discord' => \Seat\Notifications\Notifications\Structures\Discord\SkyhookDestroyed::class,
+            'slack' => \Seat\Notifications\Notifications\Structures\Slack\SkyhookDestroyed::class,
         ],
     ],
     'SkyhookLostShields' => [
         'label' => 'notifications::alerts.skyhook_lost_shields',
         'handlers' => [
-            'discord' => \Seat\Notifications\Notifications\Structures\Discord\StructureLostShields::class,
-            'slack' => \Seat\Notifications\Notifications\Structures\Slack\StructureLostShields::class,
+            'discord' => \Seat\Notifications\Notifications\Structures\Discord\SkyhookLostShields::class,
+            'slack' => \Seat\Notifications\Notifications\Structures\Slack\SkyhookLostShields::class,
         ],
     ],
     'SkyhookOnline' => [
         'label' => 'notifications::alerts.skyhook_online',
         'handlers' => [
-            'discord' => \Seat\Notifications\Notifications\Structures\Discord\StructureWentHighPower::class,
-            'slack' => \Seat\Notifications\Notifications\Structures\Slack\StructureWentHighPower::class,
+            'discord' => \Seat\Notifications\Notifications\Structures\Discord\SkyhookOnline::class,
+            'slack' => \Seat\Notifications\Notifications\Structures\Slack\SkyhookOnline::class,
         ],
     ],
     'SkyhookUnderAttack' => [
         'label' => 'notifications::alerts.skyhook_under_attack',
         'handlers' => [
-            'discord' => \Seat\Notifications\Notifications\Structures\Discord\StructureUnderAttack::class,
-            'mail' => \Seat\Notifications\Notifications\Structures\Mail\StructureUnderAttack::class,
-            'slack' => \Seat\Notifications\Notifications\Structures\Slack\StructureUnderAttack::class,
+            'discord' => \Seat\Notifications\Notifications\Structures\Discord\SkyhookUnderAttack::class,
+            'mail' => \Seat\Notifications\Notifications\Structures\Mail\SkyhookUnderAttack::class,
+            'slack' => \Seat\Notifications\Notifications\Structures\Slack\SkyhookUnderAttack::class,
         ],
     ],
     'SovCommandNodeEventStarted' => [

--- a/src/Notifications/Alliances/Discord/AllianceCapitalChanged.php
+++ b/src/Notifications/Alliances/Discord/AllianceCapitalChanged.php
@@ -65,7 +65,7 @@ class AllianceCapitalChanged extends AbstractDiscordNotification
             ->content('Capital has been modified! :white_sun_small_cloud:')
             ->embed(function (DiscordEmbed $embed) {
                 $embed->timestamp($this->notification->timestamps);
-                $embed->author('SeAT Alliance Weather', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT Alliance Weather', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) {
                     $alliance = Alliance::firstOrNew(

--- a/src/Notifications/Alliances/Discord/AllianceCapitalChanged.php
+++ b/src/Notifications/Alliances/Discord/AllianceCapitalChanged.php
@@ -22,9 +22,12 @@
 
 namespace Seat\Notifications\Notifications\Alliances\Discord;
 
-use Seat\Eveapi\Models\Alliances\Alliance;
+use Illuminate\Support\Collection;
 use Seat\Eveapi\Models\Character\CharacterNotification;
-use Seat\Eveapi\Models\Sde\SolarSystem;
+use Seat\Eveapi\Models\Sde\MapDenormalize;
+use Seat\Eveapi\Models\Universe\UniverseName;
+use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
+use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
 use Seat\Notifications\Notifications\AbstractDiscordNotification;
 use Seat\Notifications\Services\Discord\Messages\DiscordEmbed;
 use Seat\Notifications\Services\Discord\Messages\DiscordEmbedField;
@@ -36,7 +39,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Alliances\Discord
  */
-class AllianceCapitalChanged extends AbstractDiscordNotification
+class AllianceCapitalChanged extends AbstractDiscordNotification implements ExposesRequiredUniverseIds
 {
     use NotificationTools;
 
@@ -55,6 +58,21 @@ class AllianceCapitalChanged extends AbstractDiscordNotification
         $this->notification = $notification;
     }
 
+    public function middleware(): array
+    {
+        return array_merge(
+            parent::middleware(),
+            [new LoadRequiredUniverseIds]
+        );
+    }
+
+    public function getRequiredUniverseIds(): Collection
+    {
+        return collect([
+            $this->notification->text['allianceID'] ?? null,
+        ])->filter()->unique()->values();
+    }
+
     /**
      * @param  DiscordMessage  $message
      * @param  $notifiable
@@ -64,27 +82,30 @@ class AllianceCapitalChanged extends AbstractDiscordNotification
         $message
             ->content('Capital has been modified! :white_sun_small_cloud:')
             ->embed(function (DiscordEmbed $embed) {
-                $embed->timestamp($this->notification->timestamps);
+                $embed->timestamp($this->notification->timestamp);
                 $embed->author('SeAT Alliance Weather', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) {
-                    $alliance = Alliance::firstOrNew(
-                        ['alliance_id' => $this->notification->text['allianceID']],
-                        ['name' => trans('web::seat.unknown')],
+                    $alliance = UniverseName::firstOrNew(
+                        ['entity_id' => $this->notification->text['allianceID']],
+                        ['category' => 'alliance', 'name' => trans('web::seat.unknown')],
                     );
 
                     $field->name('Alliance');
-                    $field->value($this->zKillBoardToDiscordLink('alliance', $alliance->alliance_id, $alliance->name));
+                    $field->value($this->zKillBoardToDiscordLink('alliance', $alliance->entity_id, $alliance->name));
                 });
 
                 $embed->field(function (DiscordEmbedField $field) {
-                    $system = SolarSystem::find($this->notification->text['solarSystemID']);
+                    $system = MapDenormalize::firstOrNew(
+                        ['itemID' => $this->notification->text['solarSystemID']],
+                        ['itemName' => trans('web::seat.unknown'), 'security' => 0]
+                    );
 
                     $field->name('System');
                     $field->value($this->zKillBoardToDiscordLink(
                         'system',
-                        $system->system_id,
-                        sprintf('%s (%s)', $system->name, number_format($system->security, 2))
+                        $system->itemID,
+                        sprintf('%s (%s)', $system->itemName, number_format($system->security, 2))
                     ));
                 });
             })

--- a/src/Notifications/Alliances/Slack/AllianceCapitalChanged.php
+++ b/src/Notifications/Alliances/Slack/AllianceCapitalChanged.php
@@ -23,9 +23,12 @@
 namespace Seat\Notifications\Notifications\Alliances\Slack;
 
 use Illuminate\Notifications\Messages\SlackMessage;
-use Seat\Eveapi\Models\Alliances\Alliance;
+use Illuminate\Support\Collection;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
+use Seat\Eveapi\Models\Universe\UniverseName;
+use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
+use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 
@@ -34,7 +37,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Alliances\Slack
  */
-class AllianceCapitalChanged extends AbstractSlackNotification
+class AllianceCapitalChanged extends AbstractSlackNotification implements ExposesRequiredUniverseIds
 {
     use NotificationTools;
 
@@ -53,6 +56,21 @@ class AllianceCapitalChanged extends AbstractSlackNotification
         $this->notification = $notification;
     }
 
+    public function middleware(): array
+    {
+        return array_merge(
+            parent::middleware(),
+            [new LoadRequiredUniverseIds]
+        );
+    }
+
+    public function getRequiredUniverseIds(): Collection
+    {
+        return collect([
+            $this->notification->text['allianceID'] ?? null,
+        ])->filter()->unique()->values();
+    }
+
     /**
      * @param  $notifiable
      * @return \Illuminate\Notifications\Messages\SlackMessage
@@ -65,24 +83,27 @@ class AllianceCapitalChanged extends AbstractSlackNotification
             ->attachment(function ($attachment) {
                 $attachment
                     ->field(function ($field) {
-                        $alliance = Alliance::firstOrNew(
-                            ['alliance_id' => $this->notification->text['allianceID']],
-                            ['name' => trans('web::seat.unknown')]
+                        $alliance = UniverseName::firstOrNew(
+                            ['entity_id' => $this->notification->text['allianceID']],
+                            ['category' => 'alliance', 'name' => trans('web::seat.unknown')]
                         );
 
                         $field->title('Alliance')
                             ->content(
-                                $this->zKillBoardToSlackLink('alliance', $alliance->alliance_id, $alliance->name)
+                                $this->zKillBoardToSlackLink('alliance', $alliance->entity_id, $alliance->name)
                             );
                     })
                     ->field(function ($field) {
-                        $system = MapDenormalize::find($this->notification->text['solarSystemID']);
+                        $system = MapDenormalize::firstOrNew(
+                            ['itemID' => $this->notification->text['solarSystemID']],
+                            ['itemName' => trans('web::seat.unknown'), 'security' => 0]
+                        );
 
                         $field->title('System')
                             ->content(
                                 $this->zKillBoardToSlackLink(
                                     'system',
-                                    $system->itemName,
+                                    $system->itemID,
                                     sprintf('%s (%s)', $system->itemName, number_format($system->security, 2)))
                             );
                     });

--- a/src/Notifications/Characters/Discord/Killmail.php
+++ b/src/Notifications/Characters/Discord/Killmail.php
@@ -86,7 +86,7 @@ class Killmail extends AbstractDiscordNotification implements ExposesRequiredUni
         $message
             ->embed(function (DiscordEmbed $embed) {
                 $embed->timestamp($this->killmail->killmail_time);
-                $embed->author('SeAT Kilometer', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT Kilometer', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 // title
                 $embed->title(sprintf('%s destroyed in %s', $this->killmail->victim->ship->typeName, $this->killmail->solar_system->name));

--- a/src/Notifications/Characters/Discord/NewMailMessage.php
+++ b/src/Notifications/Characters/Discord/NewMailMessage.php
@@ -59,7 +59,7 @@ class NewMailMessage extends AbstractDiscordNotification
             ->content('New EVEMail Received!')
             ->embed(function (DiscordEmbed $embed) {
                 $embed->timestamp($this->message->timestamp);
-                $embed->author('SeAT Personal Agent', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT Personal Agent', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->description(Str::limit(
                     str_replace('<br>', ' ', clean_ccp_html($this->message->body->body, '<br>')),

--- a/src/Notifications/Characters/Discord/RaffleCreated.php
+++ b/src/Notifications/Characters/Discord/RaffleCreated.php
@@ -52,7 +52,7 @@ class RaffleCreated extends AbstractDiscordNotification
         $message
             ->content('A new raffle has been created!')
             ->embed(function (DiscordEmbed $embed) {
-                $embed->author('SeAT Raffle President', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT Raffle President', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) {
                     $location = MapDenormalize::firstOrNew(

--- a/src/Notifications/Characters/Discord/RaffleExpired.php
+++ b/src/Notifications/Characters/Discord/RaffleExpired.php
@@ -52,7 +52,7 @@ class RaffleExpired extends AbstractDiscordNotification
         $message
             ->content('A raffle has reach end of life!')
             ->embed(function (DiscordEmbed $embed) {
-                $embed->author('SeAT Raffle President', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT Raffle President', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) {
                     $location = MapDenormalize::firstOrNew(

--- a/src/Notifications/Characters/Discord/RaffleFinished.php
+++ b/src/Notifications/Characters/Discord/RaffleFinished.php
@@ -52,7 +52,7 @@ class RaffleFinished extends AbstractDiscordNotification
         $message
             ->content('A new raffle has been completed!')
             ->embed(function (DiscordEmbed $embed) {
-                $embed->author('SeAT Raffle President', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT Raffle President', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) {
                     $location = MapDenormalize::firstOrNew(

--- a/src/Notifications/Contracts/Discord/ContractNotification.php
+++ b/src/Notifications/Contracts/Discord/ContractNotification.php
@@ -50,7 +50,7 @@ class ContractNotification extends AbstractDiscordNotification
             ->content('A new event related to a contract has been recorded!')
             ->from('SeAT Contract Monitor')
             ->embed(function (DiscordEmbed $embed) {
-                $embed->author('SeAT Contract Monitor', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT Contract Monitor', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $type = $this->contract->type;
                 if ($type == 'item_exchange') {

--- a/src/Notifications/Corporations/Discord/BillPaidCorpAllMsg.php
+++ b/src/Notifications/Corporations/Discord/BillPaidCorpAllMsg.php
@@ -63,7 +63,7 @@ class BillPaidCorpAllMsg extends AbstractDiscordNotification
             ->content('A bill has been honored!')
             ->embed(function (DiscordEmbed $embed) {
                 $embed->timestamp($this->notification->timestamp);
-                $embed->author('SeAT Corporation Accountant', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT Corporation Accountant', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) {
                     $field->name('Amount')

--- a/src/Notifications/Corporations/Discord/CharLeftCorpMsg.php
+++ b/src/Notifications/Corporations/Discord/CharLeftCorpMsg.php
@@ -63,7 +63,7 @@ class CharLeftCorpMsg extends AbstractDiscordNotification
                 $embed->timestamp($this->notification->timestamp);
                 $embed->author(
                     'SeAT Corporation Supervisor',
-                    asset('web/img/favico/apple-icon-180x180.png'),
+                    asset('web/img/favicon/apple-icon-180x180.png'),
                     route('seatcore::corporation.view.default', ['corporation' => $this->notification->text['corpID']])
                 );
 

--- a/src/Notifications/Corporations/Discord/CharLeftCorpMsg.php
+++ b/src/Notifications/Corporations/Discord/CharLeftCorpMsg.php
@@ -22,8 +22,11 @@
 
 namespace Seat\Notifications\Notifications\Corporations\Discord;
 
+use Illuminate\Support\Collection;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Universe\UniverseName;
+use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
+use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
 use Seat\Notifications\Notifications\AbstractDiscordNotification;
 use Seat\Notifications\Services\Discord\Messages\DiscordEmbed;
 use Seat\Notifications\Services\Discord\Messages\DiscordEmbedField;
@@ -34,7 +37,7 @@ use Seat\Notifications\Services\Discord\Messages\DiscordMessage;
  *
  * @package Seat\Notifications\Notifications\Corporations\Discord
  */
-class CharLeftCorpMsg extends AbstractDiscordNotification
+class CharLeftCorpMsg extends AbstractDiscordNotification implements ExposesRequiredUniverseIds
 {
     /**
      * @var \Seat\Eveapi\Models\Character\CharacterNotification
@@ -49,6 +52,22 @@ class CharLeftCorpMsg extends AbstractDiscordNotification
     public function __construct(CharacterNotification $notification)
     {
         $this->notification = $notification;
+    }
+
+    public function middleware(): array
+    {
+        return array_merge(
+            parent::middleware(),
+            [new LoadRequiredUniverseIds]
+        );
+    }
+
+    public function getRequiredUniverseIds(): Collection
+    {
+        return collect([
+            $this->notification->text['corpID'] ?? null,
+            $this->notification->text['charID'] ?? null,
+        ])->filter()->unique()->values();
     }
 
     /**
@@ -68,7 +87,10 @@ class CharLeftCorpMsg extends AbstractDiscordNotification
                 );
 
                 $embed->field(function (DiscordEmbedField $field) {
-                    $corporation = UniverseName::find($this->notification->text['corpID']) ?? trans('web::seat.unknown');
+                    $corporation = UniverseName::firstOrNew(
+                        ['entity_id' => $this->notification->text['corpID']],
+                        ['category' => 'corporation', 'name' => trans('web::seat.unknown')]
+                    );
 
                     $field->name('Corporation')
                         ->value($corporation->name)
@@ -76,7 +98,10 @@ class CharLeftCorpMsg extends AbstractDiscordNotification
                 });
 
                 $embed->field(function (DiscordEmbedField $field) {
-                    $character = UniverseName::find($this->notification->text['charID']) ?? trans('web::seat.unknown');
+                    $character = UniverseName::firstOrNew(
+                        ['entity_id' => $this->notification->text['charID']],
+                        ['category' => 'character', 'name' => trans('web::seat.unknown')]
+                    );
 
                     $field->name('Character')
                         ->value($character->name)

--- a/src/Notifications/Corporations/Discord/CorpAllBillMsg.php
+++ b/src/Notifications/Corporations/Discord/CorpAllBillMsg.php
@@ -64,7 +64,7 @@ class CorpAllBillMsg extends AbstractDiscordNotification
             ->content('A new corporation bill has been issued!')
             ->embed(function (DiscordEmbed $embed) {
                 $embed->timestamp($this->notification->timestamp);
-                $embed->author('SeAT Corporation Accountant', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT Corporation Accountant', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) {
                     $field->name('Amount')

--- a/src/Notifications/Corporations/Discord/CorpAllBillMsg.php
+++ b/src/Notifications/Corporations/Discord/CorpAllBillMsg.php
@@ -22,8 +22,11 @@
 
 namespace Seat\Notifications\Notifications\Corporations\Discord;
 
+use Illuminate\Support\Collection;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Universe\UniverseName;
+use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
+use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
 use Seat\Notifications\Notifications\AbstractDiscordNotification;
 use Seat\Notifications\Services\Discord\Messages\DiscordEmbed;
 use Seat\Notifications\Services\Discord\Messages\DiscordEmbedField;
@@ -35,7 +38,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Corporations\Discord
  */
-class CorpAllBillMsg extends AbstractDiscordNotification
+class CorpAllBillMsg extends AbstractDiscordNotification implements ExposesRequiredUniverseIds
 {
     use NotificationTools;
 
@@ -52,6 +55,22 @@ class CorpAllBillMsg extends AbstractDiscordNotification
     public function __construct(CharacterNotification $notification)
     {
         $this->notification = $notification;
+    }
+
+    public function middleware(): array
+    {
+        return array_merge(
+            parent::middleware(),
+            [new LoadRequiredUniverseIds]
+        );
+    }
+
+    public function getRequiredUniverseIds(): Collection
+    {
+        return collect([
+            $this->notification->text['debtorID'] ?? null,
+            $this->notification->text['creditorID'] ?? null,
+        ])->filter()->unique()->values();
     }
 
     /**
@@ -77,18 +96,28 @@ class CorpAllBillMsg extends AbstractDiscordNotification
                 });
 
                 $embed->field(function (DiscordEmbedField $field) {
-                    $entity = UniverseName::find($this->notification->text['debtorID']) ?? trans('web::seat.unknown');
+                    $entity = UniverseName::firstOrNew(
+                        ['entity_id' => $this->notification->text['debtorID']],
+                        ['name' => trans('web::seat.unknown')]
+                    );
 
                     $field->name('Due By')
-                        ->value($entity->name)
+                        ->value(is_null($entity->category) ?
+                            $entity->name :
+                            $this->zKillBoardToDiscordLink($entity->category, $entity->entity_id, $entity->name))
                         ->long();
                 });
 
                 $embed->field(function (DiscordEmbedField $field) {
-                    $entity = UniverseName::find($this->notification->text['creditorID']) ?? trans('web::seat.unknown');
+                    $entity = UniverseName::firstOrNew(
+                        ['entity_id' => $this->notification->text['creditorID']],
+                        ['name' => trans('web::seat.unknown')]
+                    );
 
                     $field->name('Due To')
-                        ->value($entity->name)
+                        ->value(is_null($entity->category) ?
+                            $entity->name :
+                            $this->zKillBoardToDiscordLink($entity->category, $entity->entity_id, $entity->name))
                         ->long();
                 });
             })

--- a/src/Notifications/Corporations/Discord/CorpAppNewMsg.php
+++ b/src/Notifications/Corporations/Discord/CorpAppNewMsg.php
@@ -67,7 +67,7 @@ class CorpAppNewMsg extends AbstractDiscordNotification
 
                 $embed->author(
                     'SeAT - New Application',
-                    asset('web/img/favico/apple-icon-180x180.png'),
+                    asset('web/img/favicon/apple-icon-180x180.png'),
                     route('seatcore::corporation.view.default', ['corporation' => $this->notification->text['corpID']])
                 );
 

--- a/src/Notifications/Corporations/Discord/CorpAppNewMsg.php
+++ b/src/Notifications/Corporations/Discord/CorpAppNewMsg.php
@@ -22,8 +22,11 @@
 
 namespace Seat\Notifications\Notifications\Corporations\Discord;
 
+use Illuminate\Support\Collection;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Universe\UniverseName;
+use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
+use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
 use Seat\Notifications\Notifications\AbstractDiscordNotification;
 use Seat\Notifications\Services\Discord\Messages\DiscordEmbed;
 use Seat\Notifications\Services\Discord\Messages\DiscordEmbedField;
@@ -35,7 +38,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Corporations\Discord
  */
-class CorpAppNewMsg extends AbstractDiscordNotification
+class CorpAppNewMsg extends AbstractDiscordNotification implements ExposesRequiredUniverseIds
 {
     use NotificationTools;
 
@@ -52,6 +55,22 @@ class CorpAppNewMsg extends AbstractDiscordNotification
     public function __construct(CharacterNotification $notification)
     {
         $this->notification = $notification;
+    }
+
+    public function middleware(): array
+    {
+        return array_merge(
+            parent::middleware(),
+            [new LoadRequiredUniverseIds]
+        );
+    }
+
+    public function getRequiredUniverseIds(): Collection
+    {
+        return collect([
+            $this->notification->text['corpID'] ?? null,
+            $this->notification->text['charID'] ?? null,
+        ])->filter()->unique()->values();
     }
 
     /**
@@ -76,12 +95,12 @@ class CorpAppNewMsg extends AbstractDiscordNotification
                         ->name('Corporation Name')
                         ->long();
 
-                    $entity = UniverseName::find($this->notification->text['corpID']);
-                    if($entity) {
-                        $field->value($this->zKillBoardToDiscordLink('character', $entity->entity_id, $entity->name));
-                    } else {
-                        $field->value(trans('web::seat.unknown'));
-                    }
+                    $entity = UniverseName::firstOrNew(
+                        ['entity_id' => $this->notification->text['corpID']],
+                        ['category' => 'corporation', 'name' => trans('web::seat.unknown')]
+                    );
+
+                    $field->value($this->zKillBoardToDiscordLink('corporation', $entity->entity_id, $entity->name));
                 });
 
                 $embed->field(function (DiscordEmbedField $field) {
@@ -89,12 +108,12 @@ class CorpAppNewMsg extends AbstractDiscordNotification
                         ->name('Character Name')
                         ->long();
 
-                    $entity = UniverseName::find($this->notification->text['charID']);
-                    if($entity) {
-                        $field->value($this->zKillBoardToDiscordLink('character', $entity->entity_id, $entity->name));
-                    } else {
-                        $field->value(trans('web::seat.unknown'));
-                    }
+                    $entity = UniverseName::firstOrNew(
+                        ['entity_id' => $this->notification->text['charID']],
+                        ['category' => 'character', 'name' => trans('web::seat.unknown')]
+                    );
+
+                    $field->value($this->zKillBoardToDiscordLink('character', $entity->entity_id, $entity->name));
                 });
             })
             ->info();

--- a/src/Notifications/Corporations/Discord/InActiveCorpMember.php
+++ b/src/Notifications/Corporations/Discord/InActiveCorpMember.php
@@ -56,7 +56,7 @@ class InActiveCorpMember extends AbstractDiscordNotification
                 $embed->timestamp(carbon());
                 $embed->author(
                     'SeAT Corporation Supervisor',
-                    asset('web/img/favico/apple-icon-180x180.png'),
+                    asset('web/img/favicon/apple-icon-180x180.png'),
                     route('seatcore::corporation.view.default', ['corporation' => $this->member->corporation_id])
                 );
 

--- a/src/Notifications/Corporations/Mail/CharLeftCorpMsg.php
+++ b/src/Notifications/Corporations/Mail/CharLeftCorpMsg.php
@@ -23,9 +23,11 @@
 namespace Seat\Notifications\Notifications\Corporations\Mail;
 
 use Illuminate\Notifications\Messages\MailMessage;
-use Seat\Eveapi\Models\Character\CharacterInfo;
+use Illuminate\Support\Collection;
 use Seat\Eveapi\Models\Character\CharacterNotification;
-use Seat\Eveapi\Models\Corporation\CorporationInfo;
+use Seat\Eveapi\Models\Universe\UniverseName;
+use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
+use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
 use Seat\Notifications\Notifications\AbstractMailNotification;
 
 /**
@@ -33,7 +35,7 @@ use Seat\Notifications\Notifications\AbstractMailNotification;
  *
  * @package Seat\Notifications\Notifications\Corporations
  */
-class CharLeftCorpMsg extends AbstractMailNotification
+class CharLeftCorpMsg extends AbstractMailNotification implements ExposesRequiredUniverseIds
 {
 
     /**
@@ -51,6 +53,22 @@ class CharLeftCorpMsg extends AbstractMailNotification
         $this->notification = $notification;
     }
 
+    public function middleware(): array
+    {
+        return array_merge(
+            parent::middleware(),
+            [new LoadRequiredUniverseIds]
+        );
+    }
+
+    public function getRequiredUniverseIds(): Collection
+    {
+        return collect([
+            $this->notification->text['corpID'] ?? null,
+            $this->notification->text['charID'] ?? null,
+        ])->filter()->unique()->values();
+    }
+
     /**
      * @param  $notifiable
      * @return \Illuminate\Notifications\Messages\MailMessage
@@ -61,26 +79,17 @@ class CharLeftCorpMsg extends AbstractMailNotification
             ->subject('Character Left Corp Notification!')
             ->line('A character has left the corporation!');
 
-        $character = CharacterInfo::find($this->notification->text['charID']);
+        $character = UniverseName::firstOrNew(
+            ['entity_id' => $this->notification->text['charID']],
+            ['category' => 'character', 'name' => trans('web::seat.unknown')]
+        );
+        $corporation = UniverseName::firstOrNew(
+            ['entity_id' => $this->notification->text['corpID']],
+            ['category' => 'corporation', 'name' => trans('web::seat.unknown')]
+        );
 
-        $corporation = CorporationInfo::find($this->notification->text['corpID']);
-
-        if (! is_null($corporation) || ! is_null($character)) {
-
-            if (! is_null($corporation)) {
-
-                $mail->line(
-                    sprintf('Corporation: %s', $corporation->name)
-                );
-            }
-
-            if (! is_null($character)) {
-
-                $mail->line(
-                    sprintf('Character: %s', $character->name)
-                );
-            }
-        }
+        $mail->line(sprintf('Corporation: %s', $corporation->name));
+        $mail->line(sprintf('Character: %s', $character->name));
 
         return $mail;
     }

--- a/src/Notifications/Corporations/Mail/CorpAllBillMsg.php
+++ b/src/Notifications/Corporations/Mail/CorpAllBillMsg.php
@@ -23,9 +23,11 @@
 namespace Seat\Notifications\Notifications\Corporations\Mail;
 
 use Illuminate\Notifications\Messages\MailMessage;
-use Seat\Eveapi\Models\Alliances\Alliance;
+use Illuminate\Support\Collection;
 use Seat\Eveapi\Models\Character\CharacterNotification;
-use Seat\Eveapi\Models\Corporation\CorporationInfo;
+use Seat\Eveapi\Models\Universe\UniverseName;
+use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
+use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
 use Seat\Notifications\Notifications\AbstractMailNotification;
 use Seat\Notifications\Traits\NotificationTools;
 
@@ -34,7 +36,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Corporations
  */
-class CorpAllBillMsg extends AbstractMailNotification
+class CorpAllBillMsg extends AbstractMailNotification implements ExposesRequiredUniverseIds
 {
     use NotificationTools;
 
@@ -53,6 +55,22 @@ class CorpAllBillMsg extends AbstractMailNotification
         $this->notification = $notification;
     }
 
+    public function middleware(): array
+    {
+        return array_merge(
+            parent::middleware(),
+            [new LoadRequiredUniverseIds]
+        );
+    }
+
+    public function getRequiredUniverseIds(): Collection
+    {
+        return collect([
+            $this->notification->text['debtorID'] ?? null,
+            $this->notification->text['creditorID'] ?? null,
+        ])->filter()->unique()->values();
+    }
+
     /**
      * @param  $notifiable
      * @return \Illuminate\Notifications\Messages\MailMessage
@@ -68,25 +86,17 @@ class CorpAllBillMsg extends AbstractMailNotification
                     $this->mssqlTimestampToDate($this->notification->text['dueDate'])->toRfc7231String())
             );
 
-        $entity = Alliance::find($this->notification->text['creditorID']);
+        $creditor = UniverseName::firstOrNew(
+            ['entity_id' => $this->notification->text['creditorID']],
+            ['name' => trans('web::seat.unknown')]
+        );
+        $debtor = UniverseName::firstOrNew(
+            ['entity_id' => $this->notification->text['debtorID']],
+            ['name' => trans('web::seat.unknown')]
+        );
 
-        if (is_null($entity))
-            CorporationInfo::find($this->notification->text['creditorID']);
-
-        if (! is_null($entity))
-            $mail->action(
-                sprintf('Due to: %s', $entity->name),
-                sprintf('https://zkillboard.com/%s/%d', 'corporation', $entity->id));
-
-        $entity = Alliance::find($this->notification->text['debtorID']);
-
-        if (is_null($entity))
-            CorporationInfo::find($this->notification->text['debtorID']);
-
-        if (! is_null($entity))
-            $mail->action(
-                sprintf('Due by: %s', $entity->name),
-                sprintf('https://zkillboard.com/%s/%d', 'corporation', $entity->id));
+        $mail->line(sprintf('Due to: %s', $creditor->name));
+        $mail->line(sprintf('Due by: %s', $debtor->name));
 
         return $mail;
     }

--- a/src/Notifications/Corporations/Slack/CharLeftCorpMsg.php
+++ b/src/Notifications/Corporations/Slack/CharLeftCorpMsg.php
@@ -23,9 +23,11 @@
 namespace Seat\Notifications\Notifications\Corporations\Slack;
 
 use Illuminate\Notifications\Messages\SlackMessage;
-use Seat\Eveapi\Models\Character\CharacterInfo;
+use Illuminate\Support\Collection;
 use Seat\Eveapi\Models\Character\CharacterNotification;
-use Seat\Eveapi\Models\Corporation\CorporationInfo;
+use Seat\Eveapi\Models\Universe\UniverseName;
+use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
+use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 
 /**
@@ -33,7 +35,7 @@ use Seat\Notifications\Notifications\AbstractSlackNotification;
  *
  * @package Seat\Notifications\Notifications\Corporations
  */
-class CharLeftCorpMsg extends AbstractSlackNotification
+class CharLeftCorpMsg extends AbstractSlackNotification implements ExposesRequiredUniverseIds
 {
 
     /**
@@ -51,6 +53,22 @@ class CharLeftCorpMsg extends AbstractSlackNotification
         $this->notification = $notification;
     }
 
+    public function middleware(): array
+    {
+        return array_merge(
+            parent::middleware(),
+            [new LoadRequiredUniverseIds]
+        );
+    }
+
+    public function getRequiredUniverseIds(): Collection
+    {
+        return collect([
+            $this->notification->text['corpID'] ?? null,
+            $this->notification->text['charID'] ?? null,
+        ])->filter()->unique()->values();
+    }
+
     /**
      * @param  $notifiable
      * @return \Illuminate\Notifications\Messages\SlackMessage
@@ -61,35 +79,26 @@ class CharLeftCorpMsg extends AbstractSlackNotification
             ->content('A character has left corporation!')
             ->from('SeAT Corporation Supervisor');
 
-        $character = CharacterInfo::find($this->notification->text['charID']);
+        $character = UniverseName::firstOrNew(
+            ['entity_id' => $this->notification->text['charID']],
+            ['category' => 'character', 'name' => trans('web::seat.unknown')]
+        );
+        $corporation = UniverseName::firstOrNew(
+            ['entity_id' => $this->notification->text['corpID']],
+            ['category' => 'corporation', 'name' => trans('web::seat.unknown')]
+        );
 
-        $corporation = CorporationInfo::find($this->notification->text['corpID']);
-
-        if (! is_null($corporation) || ! is_null($character)) {
-
-            $message->attachment(function ($attachment) use ($character, $corporation) {
-
-                if (! is_null($corporation)) {
-
-                    $attachment->field(function ($field) use ($corporation) {
-
-                        $field->title('Corporation')
-                            ->content($corporation->name);
-                    });
-                }
-
-                if (! is_null($character)) {
-
-                    $attachment->field(function ($field) use ($character) {
-
-                        $field->title('Character')
-                            ->content($character->name);
-
-                    });
-                }
+        $message->attachment(function ($attachment) use ($character, $corporation) {
+            $attachment->field(function ($field) use ($corporation) {
+                $field->title('Corporation')
+                    ->content($corporation->name);
             });
 
-        }
+            $attachment->field(function ($field) use ($character) {
+                $field->title('Character')
+                    ->content($character->name);
+            });
+        });
 
         return $message;
     }

--- a/src/Notifications/Corporations/Slack/CorpAllBillMsg.php
+++ b/src/Notifications/Corporations/Slack/CorpAllBillMsg.php
@@ -23,9 +23,11 @@
 namespace Seat\Notifications\Notifications\Corporations\Slack;
 
 use Illuminate\Notifications\Messages\SlackMessage;
-use Seat\Eveapi\Models\Alliances\Alliance;
+use Illuminate\Support\Collection;
 use Seat\Eveapi\Models\Character\CharacterNotification;
-use Seat\Eveapi\Models\Corporation\CorporationInfo;
+use Seat\Eveapi\Models\Universe\UniverseName;
+use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
+use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 
@@ -34,7 +36,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Corporations
  */
-class CorpAllBillMsg extends AbstractSlackNotification
+class CorpAllBillMsg extends AbstractSlackNotification implements ExposesRequiredUniverseIds
 {
     use NotificationTools;
 
@@ -51,6 +53,22 @@ class CorpAllBillMsg extends AbstractSlackNotification
     public function __construct(CharacterNotification $notification)
     {
         $this->notification = $notification;
+    }
+
+    public function middleware(): array
+    {
+        return array_merge(
+            parent::middleware(),
+            [new LoadRequiredUniverseIds]
+        );
+    }
+
+    public function getRequiredUniverseIds(): Collection
+    {
+        return collect([
+            $this->notification->text['debtorID'] ?? null,
+            $this->notification->text['creditorID'] ?? null,
+        ])->filter()->unique()->values();
     }
 
     /**
@@ -77,29 +95,33 @@ class CorpAllBillMsg extends AbstractSlackNotification
 
                 });
 
-                $entity = Alliance::find($this->notification->text['creditorID']);
-
-                if (is_null($entity))
-                    CorporationInfo::find($this->notification->text['creditorID']);
+                $entity = UniverseName::firstOrNew(
+                    ['entity_id' => $this->notification->text['creditorID']],
+                    ['name' => trans('web::seat.unknown')]
+                );
 
                 if (! is_null($entity))
                     $attachment->field(function ($field) use ($entity) {
 
                         $field->title('Due To')
-                            ->content($entity->name);
+                            ->content(is_null($entity->category) ?
+                                $entity->name :
+                                $this->zKillBoardToSlackLink($entity->category, $entity->entity_id, $entity->name));
 
                     });
 
-                $entity = Alliance::find($this->notification->text['debtorID']);
-
-                if (is_null($entity))
-                    CorporationInfo::find($this->notification->text['debtorID']);
+                $entity = UniverseName::firstOrNew(
+                    ['entity_id' => $this->notification->text['debtorID']],
+                    ['name' => trans('web::seat.unknown')]
+                );
 
                 if (! is_null($entity))
                     $attachment->field(function ($field) use ($entity) {
 
                         $field->title('Due By')
-                            ->content($entity->name);
+                            ->content(is_null($entity->category) ?
+                                $entity->name :
+                                $this->zKillBoardToSlackLink($entity->category, $entity->entity_id, $entity->name));
 
                     });
             });

--- a/src/Notifications/Corporations/Slack/CorpAppNewMsg.php
+++ b/src/Notifications/Corporations/Slack/CorpAppNewMsg.php
@@ -23,8 +23,11 @@
 namespace Seat\Notifications\Notifications\Corporations\Slack;
 
 use Illuminate\Notifications\Messages\SlackMessage;
+use Illuminate\Support\Collection;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Universe\UniverseName;
+use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
+use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 
@@ -33,7 +36,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Corporations\Slack
  */
-class CorpAppNewMsg extends AbstractSlackNotification
+class CorpAppNewMsg extends AbstractSlackNotification implements ExposesRequiredUniverseIds
 {
     use NotificationTools;
 
@@ -52,6 +55,22 @@ class CorpAppNewMsg extends AbstractSlackNotification
         $this->notification = $notification;
     }
 
+    public function middleware(): array
+    {
+        return array_merge(
+            parent::middleware(),
+            [new LoadRequiredUniverseIds]
+        );
+    }
+
+    public function getRequiredUniverseIds(): Collection
+    {
+        return collect([
+            $this->notification->text['corpID'] ?? null,
+            $this->notification->text['charID'] ?? null,
+        ])->filter()->unique()->values();
+    }
+
     /**
      * @param  $notifiable
      * @return \Illuminate\Notifications\Messages\SlackMessage
@@ -66,7 +85,7 @@ class CorpAppNewMsg extends AbstractSlackNotification
                     ->field(function ($field) {
                         $corporation = UniverseName::firstOrNew(
                             ['entity_id' => $this->notification->text['corpID']],
-                            ['name' => trans('web::seat.unknown')]
+                            ['category' => 'corporation', 'name' => trans('web::seat.unknown')]
                         );
 
                         $field->title('Corporation')
@@ -80,7 +99,7 @@ class CorpAppNewMsg extends AbstractSlackNotification
                     ->field(function ($field) {
                         $character = UniverseName::firstOrNew(
                             ['entity_id' => $this->notification->text['charID']],
-                            ['name' => trans('web::seat.unknown')]
+                            ['category' => 'character', 'name' => trans('web::seat.unknown')]
                         );
 
                         $field->title('Character')

--- a/src/Notifications/Seat/Discord/CreatedUser.php
+++ b/src/Notifications/Seat/Discord/CreatedUser.php
@@ -62,7 +62,7 @@ class CreatedUser extends AbstractDiscordNotification
                 $embed->timestamp(carbon());
                 $embed->author(
                     'SeAT State of Things',
-                    asset('web/img/favico/apple-icon-180x180.png'),
+                    asset('web/img/favicon/apple-icon-180x180.png'),
                     route('seatcore::character.view.default', [$this->user->main_character_id]));
 
                 $embed->field(function (DiscordEmbedField $field) {

--- a/src/Notifications/Seat/Discord/DisabledToken.php
+++ b/src/Notifications/Seat/Discord/DisabledToken.php
@@ -64,7 +64,7 @@ class DisabledToken extends AbstractDiscordNotification
                 $embed->timestamp(carbon());
                 $embed->author(
                     'SeAT State of Things',
-                    asset('web/img/favico/apple-icon-180x180.png'),
+                    asset('web/img/favicon/apple-icon-180x180.png'),
                     route('seatcore::corporation.view.tracking', [
                         'corporation_id' => $this->token->affiliation->corporation_id,
                     ]));

--- a/src/Notifications/Seat/Discord/EnabledToken.php
+++ b/src/Notifications/Seat/Discord/EnabledToken.php
@@ -59,7 +59,7 @@ class EnabledToken extends AbstractDiscordNotification
                 $embed->timestamp(carbon());
                 $embed->author(
                     'SeAT State of Things',
-                    asset('web/img/favico/apple-icon-180x180.png'),
+                    asset('web/img/favicon/apple-icon-180x180.png'),
                     route('seatcore::corporation.view.tracking', [
                         'corporation_id' => $this->token->affiliation->corporation_id,
                     ]));

--- a/src/Notifications/Seat/Discord/SquadApplicationNotification.php
+++ b/src/Notifications/Seat/Discord/SquadApplicationNotification.php
@@ -47,7 +47,7 @@ class SquadApplicationNotification extends AbstractDiscordNotification
             ->warning()
             ->content('A SeAT Squad has a new Application!')
             ->embed(function (DiscordEmbed $embed) {
-                $embed->author('SeAT State of Things', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT State of Things', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->title('Squad Application', $this->application->squad->link)
                     ->fields([

--- a/src/Notifications/Seat/Discord/SquadMemberNotification.php
+++ b/src/Notifications/Seat/Discord/SquadMemberNotification.php
@@ -55,7 +55,7 @@ class SquadMemberNotification extends AbstractDiscordNotification
             ->success()
             ->content('A SeAT Squad has a new Member!')
             ->embed(function (DiscordEmbed $embed) {
-                $embed->author('SeAT State of Things', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT State of Things', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->title('Squad', $this->squad->link)
                     ->fields([

--- a/src/Notifications/Seat/Discord/SquadMemberRemovedNotification.php
+++ b/src/Notifications/Seat/Discord/SquadMemberRemovedNotification.php
@@ -61,7 +61,7 @@ class SquadMemberRemovedNotification extends AbstractDiscordNotification
             ->error()
             ->content('A SeAT Squad has lost a Member!')
             ->embed(function (DiscordEmbed $embed) {
-                $embed->author('SeAT State of Things', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT State of Things', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->title('Squad', $this->squad->link)
                     ->fields([

--- a/src/Notifications/Sovereignties/Discord/EntosisCaptureStarted.php
+++ b/src/Notifications/Sovereignties/Discord/EntosisCaptureStarted.php
@@ -65,7 +65,7 @@ class EntosisCaptureStarted extends AbstractDiscordNotification
             ->content('A sovereignty structure is beeing captured!')
             ->embed(function (DiscordEmbed $embed) {
                 $embed->timestamp($this->notification->timestamp);
-                $embed->author('SeAT Sovereignty Health', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT Sovereignty Health', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) {
                     $system = MapDenormalize::find($this->notification->text['solarSystemID']);

--- a/src/Notifications/Sovereignties/Discord/SovCommandNodeEventStarted.php
+++ b/src/Notifications/Sovereignties/Discord/SovCommandNodeEventStarted.php
@@ -64,7 +64,7 @@ class SovCommandNodeEventStarted extends AbstractDiscordNotification
             ->content('A sovereignty command node event started!')
             ->embed(function (DiscordEmbed $embed) {
                 $embed->timestamp($this->notification->timestamp);
-                $embed->author('SeAT Sovereignty Health', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT Sovereignty Health', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) {
                     $system = MapDenormalize::find($this->notification->text['solarSystemID']);

--- a/src/Notifications/Sovereignties/Discord/SovStructureDestroyed.php
+++ b/src/Notifications/Sovereignties/Discord/SovStructureDestroyed.php
@@ -65,7 +65,7 @@ class SovStructureDestroyed extends AbstractDiscordNotification
             ->content('A sovereignty structure has been destroyed! :skull:')
             ->embed(function (DiscordEmbed $embed) {
                 $embed->timestamp($this->notification->timestamp);
-                $embed->author('SeAT Sovereignty Health', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT Sovereignty Health', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) {
                     $system = MapDenormalize::find($this->notification->text['solarSystemID']);

--- a/src/Notifications/Sovereignties/Discord/SovStructureReinforced.php
+++ b/src/Notifications/Sovereignties/Discord/SovStructureReinforced.php
@@ -67,12 +67,15 @@ class SovStructureReinforced extends AbstractDiscordNotification
                 $embed->author('SeAT Sovereignty Health', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) {
-                    $system = MapDenormalize::find($this->notification->text['solarSystemID']);
+                    $system = MapDenormalize::firstOrNew(
+                        ['itemID' => $this->notification->text['solarSystemID']],
+                        ['itemName' => trans('web::seat.unknown'), 'security' => 0]
+                    );
 
                     $field->name('System')
                         ->value($this->zKillBoardToDiscordLink(
                             'system',
-                            $system->itemId,
+                            $system->itemID,
                             sprintf('%s (%s)', $system->itemName, number_format($system->security, 2))));
                 });
 

--- a/src/Notifications/Sovereignties/Discord/SovStructureReinforced.php
+++ b/src/Notifications/Sovereignties/Discord/SovStructureReinforced.php
@@ -64,7 +64,7 @@ class SovStructureReinforced extends AbstractDiscordNotification
             ->content('A sovereignty structure has been reinforced! :broken_heart:')
             ->embed(function (DiscordEmbed $embed) {
                 $embed->timestamp($this->notification->timestamp);
-                $embed->author('SeAT Sovereignty Health', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT Sovereignty Health', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) {
                     $system = MapDenormalize::find($this->notification->text['solarSystemID']);

--- a/src/Notifications/Sovereignties/Mail/SovStructureReinforced.php
+++ b/src/Notifications/Sovereignties/Mail/SovStructureReinforced.php
@@ -58,7 +58,10 @@ class SovStructureReinforced extends AbstractMailNotification
      */
     public function toMail($notifiable)
     {
-        $system = MapDenormalize::find($this->notification->text['solarSystemID']);
+        $system = MapDenormalize::firstOrNew(
+            ['itemID' => $this->notification->text['solarSystemID']],
+            ['itemName' => trans('web::seat.unknown'), 'security' => 0]
+        );
 
         return (new MailMessage)
             ->subject('Sovereignty Structure Reinforced Notification!')

--- a/src/Notifications/Sovereignties/Slack/SovStructureReinforced.php
+++ b/src/Notifications/Sovereignties/Slack/SovStructureReinforced.php
@@ -63,7 +63,10 @@ class SovStructureReinforced extends AbstractSlackNotification
             ->from('SeAT Sovereignty Health')
             ->attachment(function ($attachment) {
                 $attachment->field(function ($field) {
-                        $system = MapDenormalize::find($this->notification->text['solarSystemID']);
+                        $system = MapDenormalize::firstOrNew(
+                            ['itemID' => $this->notification->text['solarSystemID']],
+                            ['itemName' => trans('web::seat.unknown'), 'security' => 0]
+                        );
 
                         $field->title('System')
                             ->content(

--- a/src/Notifications/Structures/Discord/AllAnchoringMsg.php
+++ b/src/Notifications/Structures/Discord/AllAnchoringMsg.php
@@ -55,7 +55,7 @@ class AllAnchoringMsg extends AbstractDiscordNotification
             ->embed(function (DiscordEmbed $embed) {
                 $embed->timestamp($this->notification->timestamp);
                 $embed->color(DiscordMessage::INFO);
-                $embed->author('SeAT Structure Monitor', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT Structure Monitor', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed
                     ->field(function (DiscordEmbedField $field) {

--- a/src/Notifications/Structures/Discord/AllAnchoringMsg.php
+++ b/src/Notifications/Structures/Discord/AllAnchoringMsg.php
@@ -22,10 +22,13 @@
 
 namespace Seat\Notifications\Notifications\Structures\Discord;
 
+use Illuminate\Support\Collection;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
 use Seat\Eveapi\Models\Universe\UniverseName;
+use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
+use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
 use Seat\Notifications\Notifications\AbstractDiscordNotification;
 use Seat\Notifications\Services\Discord\Messages\DiscordEmbed;
 use Seat\Notifications\Services\Discord\Messages\DiscordEmbedField;
@@ -37,7 +40,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Structures\Slack
  */
-class AllAnchoringMsg extends AbstractDiscordNotification
+class AllAnchoringMsg extends AbstractDiscordNotification implements ExposesRequiredUniverseIds
 {
     use NotificationTools;
 
@@ -46,6 +49,21 @@ class AllAnchoringMsg extends AbstractDiscordNotification
     public function __construct(CharacterNotification $notification)
     {
         $this->notification = $notification;
+    }
+
+    public function middleware(): array
+    {
+        return array_merge(
+            parent::middleware(),
+            [new LoadRequiredUniverseIds]
+        );
+    }
+
+    public function getRequiredUniverseIds(): Collection
+    {
+        return collect([
+            $this->notification->text['corpID'] ?? null,
+        ])->filter()->unique()->values();
     }
 
     public function populateMessage(DiscordMessage $message, $notifiable): void
@@ -59,7 +77,10 @@ class AllAnchoringMsg extends AbstractDiscordNotification
 
                 $embed
                     ->field(function (DiscordEmbedField $field) {
-                        $system = MapDenormalize::find($this->notification->text['solarSystemID']);
+                        $system = MapDenormalize::firstOrNew(
+                            ['itemID' => $this->notification->text['solarSystemID']],
+                            ['itemName' => trans('web::seat.unknown'), 'security' => 0]
+                        );
 
                         $field->name('System')
                             ->value(
@@ -71,7 +92,10 @@ class AllAnchoringMsg extends AbstractDiscordNotification
                             );
                     })
                     ->field(function (DiscordEmbedField $field) {
-                        $moon = MapDenormalize::find($this->notification->text['moonID']);
+                        $moon = MapDenormalize::firstOrNew(
+                            ['itemID' => $this->notification->text['moonID']],
+                            ['itemName' => trans('web::seat.unknown')]
+                        );
 
                         $field->name('Moon')
                             ->value($moon->itemName);
@@ -82,14 +106,17 @@ class AllAnchoringMsg extends AbstractDiscordNotification
                     ->field(function (DiscordEmbedField $field) {
                         $corporation = UniverseName::firstOrNew(
                             ['entity_id' => $this->notification->text['corpID']],
-                            ['name' => trans('web::seat.unkown')]
+                            ['category' => 'corporation', 'name' => trans('web::seat.unknown')]
                         );
 
                         $field->name('Corporation')
-                            ->value($corporation->name);
+                            ->value($this->zKillBoardToDiscordLink('corporation', $corporation->entity_id, $corporation->name));
                     })
                     ->field(function (DiscordEmbedField $field) {
-                        $type = InvType::find($this->notification->text['typeID']);
+                        $type = InvType::firstOrNew(
+                            ['typeID' => $this->notification->text['typeID']],
+                            ['typeName' => trans('web::seat.unknown')]
+                        );
 
                         $field->name('Structure')
                             ->value(

--- a/src/Notifications/Structures/Discord/MoonMiningExtractionFinished.php
+++ b/src/Notifications/Structures/Discord/MoonMiningExtractionFinished.php
@@ -48,7 +48,7 @@ class MoonMiningExtractionFinished extends AbstractDiscordMoonMiningExtraction
             ->embed(function (DiscordEmbed $embed) {
                 $embed->timestamp($this->notification->timestamp);
                 $embed->color(DiscordMessage::SUCCESS);
-                $embed->author('SeAT Moon Tracker', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT Moon Tracker', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) {
                     $system = MapDenormalize::find($this->notification->text['solarSystemID']);

--- a/src/Notifications/Structures/Discord/MoonMiningExtractionStarted.php
+++ b/src/Notifications/Structures/Discord/MoonMiningExtractionStarted.php
@@ -48,7 +48,7 @@ class MoonMiningExtractionStarted extends AbstractDiscordMoonMiningExtraction
             ->embed(function (DiscordEmbed $embed) {
                 $embed->timestamp($this->notification->timestamp);
                 $embed->color(DiscordMessage::INFO);
-                $embed->author('SeAT Moon Tracker', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT Moon Tracker', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) {
                     $system = MapDenormalize::find($this->notification->text['solarSystemID']);

--- a/src/Notifications/Structures/Discord/OrbitalAttacked.php
+++ b/src/Notifications/Structures/Discord/OrbitalAttacked.php
@@ -54,7 +54,7 @@ class OrbitalAttacked extends AbstractDiscordNotification
             ->embed(function (DiscordEmbed $embed) {
                 $embed->timestamp($this->notification->timestamp);
                 $embed->color(DiscordMessage::ERROR);
-                $embed->author('SeAT Structure Monitor', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT Structure Monitor', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) {
                     $field->name('Attacker')

--- a/src/Notifications/Structures/Discord/OrbitalAttacked.php
+++ b/src/Notifications/Structures/Discord/OrbitalAttacked.php
@@ -49,24 +49,40 @@ class OrbitalAttacked extends AbstractDiscordNotification
 
     public function populateMessage(DiscordMessage $message, $notifiable): void
     {
+        $aggressor_character = UniverseName::firstOrNew(
+            ['entity_id' => $this->notification->text['aggressorID']],
+            ['category' => 'character', 'name' => trans('web::seat.unknown')]
+        );
+        $aggressor_corporation = UniverseName::firstOrNew(
+            ['entity_id' => $this->notification->text['aggressorCorpID']],
+            ['category' => 'corporation', 'name' => trans('web::seat.unknown')]
+        );
+
         $message
             ->content('A customs office is under attack!')
-            ->embed(function (DiscordEmbed $embed) {
+            ->embed(function (DiscordEmbed $embed) use ($aggressor_character, $aggressor_corporation) {
                 $embed->timestamp($this->notification->timestamp);
                 $embed->color(DiscordMessage::ERROR);
                 $embed->author('SeAT Structure Monitor', asset('web/img/favicon/apple-icon-180x180.png'));
 
-                $embed->field(function (DiscordEmbedField $field) {
-                    $field->name('Attacker')
+                $embed->field(function (DiscordEmbedField $field) use ($aggressor_character) {
+                    $field->name('Character')
+                        ->value(
+                            $this->zKillBoardToDiscordLink(
+                                'character',
+                                $this->notification->text['aggressorID'],
+                                $aggressor_character->name
+                            )
+                        );
+                });
+
+                $embed->field(function (DiscordEmbedField $field) use ($aggressor_corporation) {
+                    $field->name('Corporation')
                         ->value(
                             $this->zKillBoardToDiscordLink(
                                 'corporation',
                                 $this->notification->text['aggressorCorpID'],
-                                UniverseName::firstOrNew(
-                                    ['entity_id' => $this->notification->text['aggressorCorpID']],
-                                    ['category' => 'corporation', 'name' => trans('web::seat.unknown')]
-                                )
-                                    ->name
+                                $aggressor_corporation->name
                             )
                         );
                 });

--- a/src/Notifications/Structures/Discord/OrbitalReinforced.php
+++ b/src/Notifications/Structures/Discord/OrbitalReinforced.php
@@ -25,6 +25,7 @@ namespace Seat\Notifications\Notifications\Structures\Discord;
 use Illuminate\Support\Collection;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
+use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Universe\UniverseName;
 use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
 use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
@@ -34,12 +35,7 @@ use Seat\Notifications\Services\Discord\Messages\DiscordEmbedField;
 use Seat\Notifications\Services\Discord\Messages\DiscordMessage;
 use Seat\Notifications\Traits\NotificationTools;
 
-/**
- * Class OrbitalAttacked.
- *
- * @package Seat\Notifications\Notifications\Structures\Slack
- */
-class OrbitalAttacked extends AbstractDiscordNotification implements ExposesRequiredUniverseIds
+class OrbitalReinforced extends AbstractDiscordNotification implements ExposesRequiredUniverseIds
 {
     use NotificationTools;
 
@@ -77,95 +73,82 @@ class OrbitalAttacked extends AbstractDiscordNotification implements ExposesRequ
             ['entity_id' => $this->notification->text['aggressorCorpID']],
             ['category' => 'corporation', 'name' => trans('web::seat.unknown')]
         );
+        $type = InvType::firstOrNew(
+            ['typeID' => $this->notification->text['typeID']],
+            ['typeName' => trans('web::seat.unknown')]
+        );
 
         $message
-            ->content('A customs office is under attack!')
+            ->content('A customs office has been reinforced!')
             ->embed(function (DiscordEmbed $embed) use ($aggressor_character, $aggressor_corporation) {
                 $embed->timestamp($this->notification->timestamp);
-                $embed->color(DiscordMessage::ERROR);
+                $embed->color(DiscordMessage::WARNING);
                 $embed->author('SeAT Structure Monitor', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) use ($aggressor_character) {
                     $field->name('Character')
-                        ->value(
-                            $this->zKillBoardToDiscordLink(
-                                'character',
-                                $this->notification->text['aggressorID'],
-                                $aggressor_character->name
-                            )
-                        );
+                        ->value($this->zKillBoardToDiscordLink(
+                            'character',
+                            $this->notification->text['aggressorID'],
+                            $aggressor_character->name
+                        ));
                 });
 
                 $embed->field(function (DiscordEmbedField $field) use ($aggressor_corporation) {
                     $field->name('Corporation')
-                        ->value(
-                            $this->zKillBoardToDiscordLink(
-                                'corporation',
-                                $this->notification->text['aggressorCorpID'],
-                                $aggressor_corporation->name
-                            )
-                        );
+                        ->value($this->zKillBoardToDiscordLink(
+                            'corporation',
+                            $this->notification->text['aggressorCorpID'],
+                            $aggressor_corporation->name
+                        ));
                 });
 
-                if (array_key_exists('aggressorAllianceID', $this->notification->text) && ! is_null(
-                    $this->notification->text['aggressorAllianceID']
-                    )) {
+                if (array_key_exists('aggressorAllianceID', $this->notification->text) && ! is_null($this->notification->text['aggressorAllianceID'])) {
                     $embed->field(function (DiscordEmbedField $field) {
-
                         $field->name('Alliance')
-                            ->value(
-                                $this->zKillBoardToDiscordLink(
-                                    'alliance',
-                                    $this->notification->text['aggressorAllianceID'],
-                                    UniverseName::firstOrNew(
-                                        ['entity_id' => $this->notification->text['aggressorAllianceID']],
-                                        ['category' => 'alliance', 'name' => trans('web::seat.unknown')]
-                                    )
-                                        ->name
-                                )
-                            );
+                            ->value($this->zKillBoardToDiscordLink(
+                                'alliance',
+                                $this->notification->text['aggressorAllianceID'],
+                                UniverseName::firstOrNew(
+                                    ['entity_id' => $this->notification->text['aggressorAllianceID']],
+                                    ['category' => 'alliance', 'name' => trans('web::seat.unknown')]
+                                )->name
+                            ));
                     });
                 }
             })
-            ->embed(function (DiscordEmbed $embed) {
+            ->embed(function (DiscordEmbed $embed) use ($type) {
                 $embed->field(function (DiscordEmbedField $field) {
                     $system = MapDenormalize::find($this->notification->text['solarSystemID']);
 
                     $field->name('System')
-                        ->value(
-                            $this->zKillBoardToDiscordLink(
-                                'system',
-                                $system->itemID,
-                                $system->itemName . ' (' . number_format($system->security, 2) . ')'
-                            )
-                        );
-                })
-                    ->field(function (DiscordEmbedField $field) {
-                        $planet = MapDenormalize::find($this->notification->text['planetID']);
+                        ->value($this->zKillBoardToDiscordLink(
+                            'system',
+                            $system->itemID,
+                            $system->itemName . ' (' . number_format($system->security, 2) . ')'
+                        ));
+                })->field(function (DiscordEmbedField $field) {
+                    $planet = MapDenormalize::find($this->notification->text['planetID']);
 
-                        $field->name('Planet')
-                            ->value(
-                                $this->zKillBoardToDiscordLink(
-                                    'location',
-                                    $planet->itemID,
-                                    $planet->itemName . ' (' . number_format($planet->security, 2) . ')'
-                                )
-                            );
-                    });
+                    $field->name('Planet')
+                        ->value($this->zKillBoardToDiscordLink(
+                            'location',
+                            $planet->itemID,
+                            $planet->itemName
+                        ));
+                })->field(function (DiscordEmbedField $field) use ($type) {
+                    $field->name('Structure')
+                        ->value($this->zKillBoardToDiscordLink('ship', $type->typeID, $type->typeName));
+                });
             })
             ->embed(function (DiscordEmbed $embed) {
                 $embed->field(function (DiscordEmbedField $field) {
-                    $field->name('Shield')
-                        ->value(number_format($this->notification->text['shieldLevel'] * 100, 2));
-                })->color(DiscordMessage::SUCCESS);
-
-                if ($this->notification->text['shieldLevel'] * 100 < 70) {
-                    $embed->color(DiscordMessage::WARNING);
-                }
-
-                if ($this->notification->text['shieldLevel'] * 100 < 40) {
-                    $embed->color(DiscordMessage::ERROR);
-                }
+                    $field->name('Reinforcement Exit (UTC)')
+                        ->value($this->mssqlTimestampToDate($this->notification->text['reinforceExitTime'])
+                            ->setTimezone('UTC')
+                            ->format('Y.m.d H:i:s'))
+                        ->long();
+                })->color(DiscordMessage::WARNING);
             });
     }
 }

--- a/src/Notifications/Structures/Discord/OwnershipTransferred.php
+++ b/src/Notifications/Structures/Discord/OwnershipTransferred.php
@@ -55,7 +55,7 @@ class OwnershipTransferred extends AbstractDiscordNotification
             ->embed(function (DiscordEmbed $embed) {
                 $embed->timestamp($this->notification->timestamp);
                 $embed->color(DiscordMessage::INFO);
-                $embed->author('SeAT Structure Monitor', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT Structure Monitor', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) {
                     $system = MapDenormalize::find($this->notification->text['solarSystemID']);

--- a/src/Notifications/Structures/Discord/OwnershipTransferred.php
+++ b/src/Notifications/Structures/Discord/OwnershipTransferred.php
@@ -22,10 +22,13 @@
 
 namespace Seat\Notifications\Notifications\Structures\Discord;
 
+use Illuminate\Support\Collection;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
 use Seat\Eveapi\Models\Universe\UniverseName;
+use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
+use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
 use Seat\Notifications\Notifications\AbstractDiscordNotification;
 use Seat\Notifications\Services\Discord\Messages\DiscordEmbed;
 use Seat\Notifications\Services\Discord\Messages\DiscordEmbedField;
@@ -37,7 +40,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Structures
  */
-class OwnershipTransferred extends AbstractDiscordNotification
+class OwnershipTransferred extends AbstractDiscordNotification implements ExposesRequiredUniverseIds
 {
     use NotificationTools;
 
@@ -46,6 +49,22 @@ class OwnershipTransferred extends AbstractDiscordNotification
     public function __construct(CharacterNotification $notification)
     {
         $this->notification = $notification;
+    }
+
+    public function middleware(): array
+    {
+        return array_merge(
+            parent::middleware(),
+            [new LoadRequiredUniverseIds]
+        );
+    }
+
+    public function getRequiredUniverseIds(): Collection
+    {
+        return collect([
+            $this->notification->text['oldOwnerCorpID'] ?? null,
+            $this->notification->text['newOwnerCorpID'] ?? null,
+        ])->filter()->unique()->values();
     }
 
     public function populateMessage(DiscordMessage $message, $notifiable): void
@@ -58,7 +77,10 @@ class OwnershipTransferred extends AbstractDiscordNotification
                 $embed->author('SeAT Structure Monitor', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) {
-                    $system = MapDenormalize::find($this->notification->text['solarSystemID']);
+                    $system = MapDenormalize::firstOrNew(
+                        ['itemID' => $this->notification->text['solarSystemID']],
+                        ['itemName' => trans('web::seat.unknown'), 'security' => 0]
+                    );
 
                     $field->name('System')
                         ->value(
@@ -71,7 +93,10 @@ class OwnershipTransferred extends AbstractDiscordNotification
                 });
 
                 $embed->field(function (DiscordEmbedField $field) {
-                    $type = InvType::find($this->notification->text['structureTypeID']);
+                    $type = InvType::firstOrNew(
+                        ['typeID' => $this->notification->text['structureTypeID']],
+                        ['typeName' => trans('web::seat.unknown')]
+                    );
 
                     $field->name('Structure')
                         ->value(sprintf('%s | %s', $type->typeName, $this->notification->text['structureName']));
@@ -81,7 +106,7 @@ class OwnershipTransferred extends AbstractDiscordNotification
                 $embed->field(function (DiscordEmbedField $field) {
                     $old = UniverseName::firstOrNew(
                         ['entity_id' => $this->notification->text['oldOwnerCorpID']],
-                        ['name' => trans('web::seat.unknown')]
+                        ['category' => 'corporation', 'name' => trans('web::seat.unknown')]
                     );
 
                     $field->name('Old Corporation')
@@ -91,7 +116,7 @@ class OwnershipTransferred extends AbstractDiscordNotification
                 $embed->field(function (DiscordEmbedField $field) {
                     $new = UniverseName::firstOrNew(
                         ['entity_id' => $this->notification->text['newOwnerCorpID']],
-                        ['name' => trans('web::seat.unknown')]
+                        ['category' => 'corporation', 'name' => trans('web::seat.unknown')]
                     );
 
                     $field->name('New Corporation')

--- a/src/Notifications/Structures/Discord/SkyhookDeployed.php
+++ b/src/Notifications/Structures/Discord/SkyhookDeployed.php
@@ -89,8 +89,9 @@ class SkyhookDeployed extends AbstractDiscordNotification
             })
             ->embed(function (DiscordEmbed $embed) {
                 $embed->field(function (DiscordEmbedField $field) {
-                    $field->name('Remaining Time')
-                        ->value((string) $this->notification->text['timeLeft']);
+                    $field->name('Online At (UTC)')
+                        ->value($this->eveDurationToDateTimeString($this->notification->text['timeLeft'], $this->notification->timestamp))
+                        ->long();
                 });
 
                 $embed->color(DiscordMessage::WARNING);

--- a/src/Notifications/Structures/Discord/SkyhookDeployed.php
+++ b/src/Notifications/Structures/Discord/SkyhookDeployed.php
@@ -52,7 +52,7 @@ class SkyhookDeployed extends AbstractDiscordNotification
 
                 $embed->timestamp($this->notification->timestamp);
                 $embed->color(DiscordMessage::INFO);
-                $embed->author('SeAT Structure Monitor', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT Structure Monitor', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) use ($system) {
                     $field->name('System')

--- a/src/Notifications/Structures/Discord/SkyhookDeployed.php
+++ b/src/Notifications/Structures/Discord/SkyhookDeployed.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Notifications\Notifications\Structures\Discord;
+
+use Seat\Eveapi\Models\Character\CharacterNotification;
+use Seat\Notifications\Notifications\AbstractDiscordNotification;
+use Seat\Notifications\Notifications\Structures\Traits\SkyhookNotificationTools;
+use Seat\Notifications\Services\Discord\Messages\DiscordEmbed;
+use Seat\Notifications\Services\Discord\Messages\DiscordEmbedField;
+use Seat\Notifications\Services\Discord\Messages\DiscordMessage;
+use Seat\Notifications\Traits\NotificationTools;
+
+class SkyhookDeployed extends AbstractDiscordNotification
+{
+    use NotificationTools;
+    use SkyhookNotificationTools;
+
+    private CharacterNotification $notification;
+
+    public function __construct(CharacterNotification $notification)
+    {
+        $this->notification = $notification;
+    }
+
+    public function populateMessage(DiscordMessage $message, $notifiable): void
+    {
+        $message
+            ->content('A new Skyhook is deploying!')
+            ->embed(function (DiscordEmbed $embed) {
+                $system = $this->getSkyhookSystem();
+                $planet = $this->getSkyhookPlanet();
+
+                $embed->timestamp($this->notification->timestamp);
+                $embed->color(DiscordMessage::INFO);
+                $embed->author('SeAT Structure Monitor', asset('web/img/favico/apple-icon-180x180.png'));
+
+                $embed->field(function (DiscordEmbedField $field) use ($system) {
+                    $field->name('System')
+                        ->value($this->zKillBoardToDiscordLink(
+                            'system',
+                            $system->itemID,
+                            sprintf('%s (%s)', $system->itemName, number_format($system->security, 2))
+                        ));
+                });
+
+                $embed->field(function (DiscordEmbedField $field) use ($planet) {
+                    $field->name('Planet')
+                        ->value($planet->itemName);
+                });
+
+                if (array_key_exists('ownerCorpLinkData', $this->notification->text) && array_key_exists('ownerCorpName', $this->notification->text)) {
+                    $embed->field(function (DiscordEmbedField $field) {
+                        $field->name('Owner')
+                            ->value($this->zKillBoardToDiscordLink(
+                                'corporation',
+                                $this->notification->text['ownerCorpLinkData'][2],
+                                $this->notification->text['ownerCorpName']
+                            ));
+                    });
+                }
+            })
+            ->embed(function (DiscordEmbed $embed) {
+                $type = $this->getSkyhookType();
+
+                $embed->field(function (DiscordEmbedField $field) use ($type) {
+                    $field->name($this->getSkyhookName())
+                        ->value($this->zKillBoardToDiscordLink('ship', $type->typeID, $type->typeName));
+                });
+            })
+            ->embed(function (DiscordEmbed $embed) {
+                $embed->field(function (DiscordEmbedField $field) {
+                    $field->name('Remaining Time')
+                        ->value((string) $this->notification->text['timeLeft']);
+                });
+
+                $embed->color(DiscordMessage::WARNING);
+            });
+    }
+}

--- a/src/Notifications/Structures/Discord/SkyhookDestroyed.php
+++ b/src/Notifications/Structures/Discord/SkyhookDestroyed.php
@@ -52,7 +52,7 @@ class SkyhookDestroyed extends AbstractDiscordNotification
 
                 $embed->timestamp($this->notification->timestamp);
                 $embed->color(DiscordMessage::ERROR);
-                $embed->author('SeAT Structure Monitor', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT Structure Monitor', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) use ($system) {
                     $field->name('System')

--- a/src/Notifications/Structures/Discord/SkyhookDestroyed.php
+++ b/src/Notifications/Structures/Discord/SkyhookDestroyed.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Notifications\Notifications\Structures\Discord;
+
+use Seat\Eveapi\Models\Character\CharacterNotification;
+use Seat\Notifications\Notifications\AbstractDiscordNotification;
+use Seat\Notifications\Notifications\Structures\Traits\SkyhookNotificationTools;
+use Seat\Notifications\Services\Discord\Messages\DiscordEmbed;
+use Seat\Notifications\Services\Discord\Messages\DiscordEmbedField;
+use Seat\Notifications\Services\Discord\Messages\DiscordMessage;
+use Seat\Notifications\Traits\NotificationTools;
+
+class SkyhookDestroyed extends AbstractDiscordNotification
+{
+    use NotificationTools;
+    use SkyhookNotificationTools;
+
+    private CharacterNotification $notification;
+
+    public function __construct(CharacterNotification $notification)
+    {
+        $this->notification = $notification;
+    }
+
+    public function populateMessage(DiscordMessage $message, $notifiable): void
+    {
+        $message
+            ->content('A Skyhook has been destroyed!')
+            ->embed(function (DiscordEmbed $embed) {
+                $system = $this->getSkyhookSystem();
+                $planet = $this->getSkyhookPlanet();
+
+                $embed->timestamp($this->notification->timestamp);
+                $embed->color(DiscordMessage::ERROR);
+                $embed->author('SeAT Structure Monitor', asset('web/img/favico/apple-icon-180x180.png'));
+
+                $embed->field(function (DiscordEmbedField $field) use ($system) {
+                    $field->name('System')
+                        ->value($this->zKillBoardToDiscordLink(
+                            'system',
+                            $system->itemID,
+                            sprintf('%s (%s)', $system->itemName, number_format($system->security, 2))
+                        ));
+                });
+
+                $embed->field(function (DiscordEmbedField $field) use ($planet) {
+                    $field->name('Planet')
+                        ->value($planet->itemName);
+                });
+
+                if (array_key_exists('ownerCorpLinkData', $this->notification->text) && array_key_exists('ownerCorpName', $this->notification->text)) {
+                    $embed->field(function (DiscordEmbedField $field) {
+                        $field->name('Owner')
+                            ->value($this->zKillBoardToDiscordLink(
+                                'corporation',
+                                $this->notification->text['ownerCorpLinkData'][2],
+                                $this->notification->text['ownerCorpName']
+                            ));
+                    });
+                }
+            })
+            ->embed(function (DiscordEmbed $embed) {
+                $type = $this->getSkyhookType();
+
+                $embed->field(function (DiscordEmbedField $field) use ($type) {
+                    $field->name($this->getSkyhookName())
+                        ->value($this->zKillBoardToDiscordLink('ship', $type->typeID, $type->typeName));
+                });
+
+                $embed->color(DiscordMessage::ERROR);
+            });
+    }
+}

--- a/src/Notifications/Structures/Discord/SkyhookLostShields.php
+++ b/src/Notifications/Structures/Discord/SkyhookLostShields.php
@@ -22,7 +22,11 @@
 
 namespace Seat\Notifications\Notifications\Structures\Discord;
 
+use Illuminate\Support\Collection;
 use Seat\Eveapi\Models\Character\CharacterNotification;
+use Seat\Eveapi\Models\Universe\UniverseName;
+use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
+use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
 use Seat\Notifications\Notifications\AbstractDiscordNotification;
 use Seat\Notifications\Notifications\Structures\Traits\SkyhookNotificationTools;
 use Seat\Notifications\Services\Discord\Messages\DiscordEmbed;
@@ -30,7 +34,7 @@ use Seat\Notifications\Services\Discord\Messages\DiscordEmbedField;
 use Seat\Notifications\Services\Discord\Messages\DiscordMessage;
 use Seat\Notifications\Traits\NotificationTools;
 
-class SkyhookLostShields extends AbstractDiscordNotification
+class SkyhookLostShields extends AbstractDiscordNotification implements ExposesRequiredUniverseIds
 {
     use NotificationTools;
     use SkyhookNotificationTools;
@@ -42,11 +46,44 @@ class SkyhookLostShields extends AbstractDiscordNotification
         $this->notification = $notification;
     }
 
+    public function middleware(): array
+    {
+        return array_merge(
+            parent::middleware(),
+            [new LoadRequiredUniverseIds]
+        );
+    }
+
+    public function getRequiredUniverseIds(): Collection
+    {
+        return collect([
+            $this->notification->text['charID'] ?? null,
+            $this->notification->text['corpLinkData'][2] ?? null,
+            $this->notification->text['allianceID'] ?? null,
+        ])->filter()->unique()->values();
+    }
+
     public function populateMessage(DiscordMessage $message, $notifiable): void
     {
+        $character_id = $this->notification->text['charID'] ?? null;
+        $corporation_id = $this->notification->text['corpLinkData'][2] ?? null;
+        $alliance_id = $this->notification->text['allianceID'] ?? null;
+        $attacker = is_null($character_id) ? null : UniverseName::firstOrNew(
+            ['entity_id' => $character_id],
+            ['category' => 'character', 'name' => trans('web::seat.unknown')]
+        );
+        $corporation = is_null($corporation_id) ? null : UniverseName::firstOrNew(
+            ['entity_id' => $corporation_id],
+            ['category' => 'corporation', 'name' => trans('web::seat.unknown')]
+        );
+        $alliance = is_null($alliance_id) ? null : UniverseName::firstOrNew(
+            ['entity_id' => $alliance_id],
+            ['category' => 'alliance', 'name' => trans('web::seat.unknown')]
+        );
+
         $message
             ->content('A Skyhook lost Shields!')
-            ->embed(function (DiscordEmbed $embed) {
+            ->embed(function (DiscordEmbed $embed) use ($attacker, $character_id, $corporation, $corporation_id, $alliance, $alliance_id) {
                 $system = $this->getSkyhookSystem();
                 $planet = $this->getSkyhookPlanet();
                 $type = $this->getSkyhookType();
@@ -54,6 +91,29 @@ class SkyhookLostShields extends AbstractDiscordNotification
                 $embed->timestamp($this->notification->timestamp);
                 $embed->color(DiscordMessage::WARNING);
                 $embed->author('SeAT Structure Monitor', asset('web/img/favicon/apple-icon-180x180.png'));
+
+                if (! is_null($attacker) && ! is_null($character_id)) {
+                    $embed->field(function (DiscordEmbedField $field) use ($attacker, $character_id) {
+                        $field->name('Character')
+                            ->value($this->zKillBoardToDiscordLink('character', $character_id, $attacker->name));
+                    });
+                }
+
+                if (! is_null($corporation) && ! is_null($corporation_id)) {
+                    $corporation_name = $this->notification->text['corpName'] ?? $corporation->name;
+                    $embed->field(function (DiscordEmbedField $field) use ($corporation_id, $corporation_name) {
+                        $field->name('Corporation')
+                            ->value($this->zKillBoardToDiscordLink('corporation', $corporation_id, $corporation_name));
+                    });
+                }
+
+                if (! is_null($alliance) && ! is_null($alliance_id)) {
+                    $alliance_name = $this->notification->text['allianceName'] ?? $alliance->name;
+                    $embed->field(function (DiscordEmbedField $field) use ($alliance_id, $alliance_name) {
+                        $field->name('Alliance')
+                            ->value($this->zKillBoardToDiscordLink('alliance', $alliance_id, $alliance_name));
+                    });
+                }
 
                 $embed->field(function (DiscordEmbedField $field) use ($system) {
                     $field->name('System')
@@ -73,6 +133,20 @@ class SkyhookLostShields extends AbstractDiscordNotification
                     $field->name($this->getSkyhookName())
                         ->value($this->zKillBoardToDiscordLink('ship', $type->typeID, $type->typeName));
                 });
+
+                if (array_key_exists('timeLeft', $this->notification->text)) {
+                    $embed->field(function (DiscordEmbedField $field) {
+                        $field->name('Reinforcement Timer')
+                            ->value($this->eveDurationToDateTimeString($this->notification->text['timeLeft'], $this->notification->timestamp));
+                    });
+                }
+
+                if (array_key_exists('vulnerableTime', $this->notification->text)) {
+                    $embed->field(function (DiscordEmbedField $field) {
+                        $field->name('Vulnerability Window')
+                            ->value($this->eveDurationToString($this->notification->text['vulnerableTime']));
+                    });
+                }
             });
     }
 }

--- a/src/Notifications/Structures/Discord/SkyhookLostShields.php
+++ b/src/Notifications/Structures/Discord/SkyhookLostShields.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Notifications\Notifications\Structures\Discord;
+
+use Seat\Eveapi\Models\Character\CharacterNotification;
+use Seat\Notifications\Notifications\AbstractDiscordNotification;
+use Seat\Notifications\Notifications\Structures\Traits\SkyhookNotificationTools;
+use Seat\Notifications\Services\Discord\Messages\DiscordEmbed;
+use Seat\Notifications\Services\Discord\Messages\DiscordEmbedField;
+use Seat\Notifications\Services\Discord\Messages\DiscordMessage;
+use Seat\Notifications\Traits\NotificationTools;
+
+class SkyhookLostShields extends AbstractDiscordNotification
+{
+    use NotificationTools;
+    use SkyhookNotificationTools;
+
+    private CharacterNotification $notification;
+
+    public function __construct(CharacterNotification $notification)
+    {
+        $this->notification = $notification;
+    }
+
+    public function populateMessage(DiscordMessage $message, $notifiable): void
+    {
+        $message
+            ->content('A Skyhook lost Shields!')
+            ->embed(function (DiscordEmbed $embed) {
+                $system = $this->getSkyhookSystem();
+                $planet = $this->getSkyhookPlanet();
+                $type = $this->getSkyhookType();
+
+                $embed->timestamp($this->notification->timestamp);
+                $embed->color(DiscordMessage::WARNING);
+                $embed->author('SeAT Structure Monitor', asset('web/img/favico/apple-icon-180x180.png'));
+
+                $embed->field(function (DiscordEmbedField $field) use ($system) {
+                    $field->name('System')
+                        ->value($this->zKillBoardToDiscordLink(
+                            'system',
+                            $system->itemID,
+                            sprintf('%s (%s)', $system->itemName, number_format($system->security, 2))
+                        ));
+                });
+
+                $embed->field(function (DiscordEmbedField $field) use ($planet) {
+                    $field->name('Planet')
+                        ->value($planet->itemName);
+                });
+
+                $embed->field(function (DiscordEmbedField $field) use ($type) {
+                    $field->name($this->getSkyhookName())
+                        ->value($this->zKillBoardToDiscordLink('ship', $type->typeID, $type->typeName));
+                });
+            });
+    }
+}

--- a/src/Notifications/Structures/Discord/SkyhookLostShields.php
+++ b/src/Notifications/Structures/Discord/SkyhookLostShields.php
@@ -53,7 +53,7 @@ class SkyhookLostShields extends AbstractDiscordNotification
 
                 $embed->timestamp($this->notification->timestamp);
                 $embed->color(DiscordMessage::WARNING);
-                $embed->author('SeAT Structure Monitor', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT Structure Monitor', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) use ($system) {
                     $field->name('System')

--- a/src/Notifications/Structures/Discord/SkyhookOnline.php
+++ b/src/Notifications/Structures/Discord/SkyhookOnline.php
@@ -53,7 +53,7 @@ class SkyhookOnline extends AbstractDiscordNotification
 
                 $embed->timestamp($this->notification->timestamp);
                 $embed->color(DiscordMessage::SUCCESS);
-                $embed->author('SeAT Structure Monitor', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT Structure Monitor', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) use ($system) {
                     $field->name('System')

--- a/src/Notifications/Structures/Discord/SkyhookOnline.php
+++ b/src/Notifications/Structures/Discord/SkyhookOnline.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Notifications\Notifications\Structures\Discord;
+
+use Seat\Eveapi\Models\Character\CharacterNotification;
+use Seat\Notifications\Notifications\AbstractDiscordNotification;
+use Seat\Notifications\Notifications\Structures\Traits\SkyhookNotificationTools;
+use Seat\Notifications\Services\Discord\Messages\DiscordEmbed;
+use Seat\Notifications\Services\Discord\Messages\DiscordEmbedField;
+use Seat\Notifications\Services\Discord\Messages\DiscordMessage;
+use Seat\Notifications\Traits\NotificationTools;
+
+class SkyhookOnline extends AbstractDiscordNotification
+{
+    use NotificationTools;
+    use SkyhookNotificationTools;
+
+    private CharacterNotification $notification;
+
+    public function __construct(CharacterNotification $notification)
+    {
+        $this->notification = $notification;
+    }
+
+    public function populateMessage(DiscordMessage $message, $notifiable): void
+    {
+        $message
+            ->content('A Skyhook went online!')
+            ->embed(function (DiscordEmbed $embed) {
+                $system = $this->getSkyhookSystem();
+                $planet = $this->getSkyhookPlanet();
+                $type = $this->getSkyhookType();
+
+                $embed->timestamp($this->notification->timestamp);
+                $embed->color(DiscordMessage::SUCCESS);
+                $embed->author('SeAT Structure Monitor', asset('web/img/favico/apple-icon-180x180.png'));
+
+                $embed->field(function (DiscordEmbedField $field) use ($system) {
+                    $field->name('System')
+                        ->value($this->zKillBoardToDiscordLink(
+                            'system',
+                            $system->itemID,
+                            sprintf('%s (%s)', $system->itemName, number_format($system->security, 2))
+                        ));
+                });
+
+                $embed->field(function (DiscordEmbedField $field) use ($planet) {
+                    $field->name('Planet')
+                        ->value($planet->itemName);
+                });
+
+                $embed->field(function (DiscordEmbedField $field) use ($type) {
+                    $field->name($this->getSkyhookName())
+                        ->value($this->zKillBoardToDiscordLink('ship', $type->typeID, $type->typeName));
+                });
+            });
+    }
+}

--- a/src/Notifications/Structures/Discord/SkyhookUnderAttack.php
+++ b/src/Notifications/Structures/Discord/SkyhookUnderAttack.php
@@ -22,7 +22,11 @@
 
 namespace Seat\Notifications\Notifications\Structures\Discord;
 
+use Illuminate\Support\Collection;
 use Seat\Eveapi\Models\Character\CharacterNotification;
+use Seat\Eveapi\Models\Universe\UniverseName;
+use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
+use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
 use Seat\Notifications\Notifications\AbstractDiscordNotification;
 use Seat\Notifications\Notifications\Structures\Traits\SkyhookNotificationTools;
 use Seat\Notifications\Services\Discord\Messages\DiscordEmbed;
@@ -30,7 +34,7 @@ use Seat\Notifications\Services\Discord\Messages\DiscordEmbedField;
 use Seat\Notifications\Services\Discord\Messages\DiscordMessage;
 use Seat\Notifications\Traits\NotificationTools;
 
-class SkyhookUnderAttack extends AbstractDiscordNotification
+class SkyhookUnderAttack extends AbstractDiscordNotification implements ExposesRequiredUniverseIds
 {
     use NotificationTools;
     use SkyhookNotificationTools;
@@ -42,11 +46,31 @@ class SkyhookUnderAttack extends AbstractDiscordNotification
         $this->notification = $notification;
     }
 
+    public function middleware(): array
+    {
+        return array_merge(
+            parent::middleware(),
+            [new LoadRequiredUniverseIds]
+        );
+    }
+
+    public function getRequiredUniverseIds(): Collection
+    {
+        return collect([
+            $this->notification->text['charID'] ?? null,
+        ])->filter()->unique()->values();
+    }
+
     public function populateMessage(DiscordMessage $message, $notifiable): void
     {
+        $attacker = UniverseName::firstOrNew(
+            ['entity_id' => $this->notification->text['charID']],
+            ['category' => 'character', 'name' => trans('web::seat.unknown')]
+        );
+
         $message
             ->content('A Skyhook is under attack!')
-            ->embed(function (DiscordEmbed $embed) {
+            ->embed(function (DiscordEmbed $embed) use ($attacker) {
                 $system = $this->getSkyhookSystem();
                 $planet = $this->getSkyhookPlanet();
                 $type = $this->getSkyhookType();
@@ -55,8 +79,17 @@ class SkyhookUnderAttack extends AbstractDiscordNotification
                 $embed->color(DiscordMessage::ERROR);
                 $embed->author('SeAT Structure Monitor', asset('web/img/favicon/apple-icon-180x180.png'));
 
+                $embed->field(function (DiscordEmbedField $field) use ($attacker) {
+                    $field->name('Character')
+                        ->value($this->zKillBoardToDiscordLink(
+                            'character',
+                            $this->notification->text['charID'],
+                            $attacker->name
+                        ));
+                });
+
                 $embed->field(function (DiscordEmbedField $field) {
-                    $field->name('Attacker')
+                    $field->name('Corporation')
                         ->value($this->zKillBoardToDiscordLink(
                             'corporation',
                             $this->notification->text['corpLinkData'][2],

--- a/src/Notifications/Structures/Discord/SkyhookUnderAttack.php
+++ b/src/Notifications/Structures/Discord/SkyhookUnderAttack.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Notifications\Notifications\Structures\Discord;
+
+use Seat\Eveapi\Models\Character\CharacterNotification;
+use Seat\Notifications\Notifications\AbstractDiscordNotification;
+use Seat\Notifications\Notifications\Structures\Traits\SkyhookNotificationTools;
+use Seat\Notifications\Services\Discord\Messages\DiscordEmbed;
+use Seat\Notifications\Services\Discord\Messages\DiscordEmbedField;
+use Seat\Notifications\Services\Discord\Messages\DiscordMessage;
+use Seat\Notifications\Traits\NotificationTools;
+
+class SkyhookUnderAttack extends AbstractDiscordNotification
+{
+    use NotificationTools;
+    use SkyhookNotificationTools;
+
+    private CharacterNotification $notification;
+
+    public function __construct(CharacterNotification $notification)
+    {
+        $this->notification = $notification;
+    }
+
+    public function populateMessage(DiscordMessage $message, $notifiable): void
+    {
+        $message
+            ->content('A Skyhook is under attack!')
+            ->embed(function (DiscordEmbed $embed) {
+                $system = $this->getSkyhookSystem();
+                $planet = $this->getSkyhookPlanet();
+                $type = $this->getSkyhookType();
+
+                $embed->timestamp($this->notification->timestamp);
+                $embed->color(DiscordMessage::ERROR);
+                $embed->author('SeAT Structure Monitor', asset('web/img/favico/apple-icon-180x180.png'));
+
+                $embed->field(function (DiscordEmbedField $field) {
+                    $field->name('Attacker')
+                        ->value($this->zKillBoardToDiscordLink(
+                            'corporation',
+                            $this->notification->text['corpLinkData'][2],
+                            $this->notification->text['corpName']
+                        ));
+                });
+
+                if (array_key_exists('allianceID', $this->notification->text) && ! is_null($this->notification->text['allianceID'])) {
+                    $embed->field(function (DiscordEmbedField $field) {
+                        $field->name('Alliance')
+                            ->value($this->zKillBoardToDiscordLink(
+                                'alliance',
+                                $this->notification->text['allianceID'],
+                                $this->notification->text['allianceName']
+                            ));
+                    });
+                }
+
+                $embed->field(function (DiscordEmbedField $field) use ($system) {
+                    $field->name('System')
+                        ->value($this->zKillBoardToDiscordLink(
+                            'system',
+                            $system->itemID,
+                            sprintf('%s (%s)', $system->itemName, number_format($system->security, 2))
+                        ));
+                });
+
+                $embed->field(function (DiscordEmbedField $field) use ($planet) {
+                    $field->name('Planet')
+                        ->value($planet->itemName);
+                });
+
+                $embed->field(function (DiscordEmbedField $field) use ($type) {
+                    $field->name($this->getSkyhookName())
+                        ->value($this->zKillBoardToDiscordLink('ship', $type->typeID, $type->typeName));
+                });
+            })
+            ->embed(function (DiscordEmbed $embed) {
+                $embed->field(function (DiscordEmbedField $field) {
+                    $field->name('Shield')
+                        ->value(number_format($this->notification->text['shieldPercentage'], 2));
+                })->color(DiscordMessage::SUCCESS);
+
+                if ($this->notification->text['shieldPercentage'] < 70) {
+                    $embed->color(DiscordMessage::WARNING);
+                }
+
+                if ($this->notification->text['shieldPercentage'] < 40) {
+                    $embed->color(DiscordMessage::ERROR);
+                }
+            })
+            ->embed(function (DiscordEmbed $embed) {
+                $embed->field(function (DiscordEmbedField $field) {
+                    $field->name('Armor')
+                        ->value(number_format($this->notification->text['armorPercentage'], 2));
+                })->color(DiscordMessage::SUCCESS);
+
+                if ($this->notification->text['armorPercentage'] < 70) {
+                    $embed->color(DiscordMessage::WARNING);
+                }
+
+                if ($this->notification->text['armorPercentage'] < 40) {
+                    $embed->color(DiscordMessage::ERROR);
+                }
+            })
+            ->embed(function (DiscordEmbed $embed) {
+                $embed->field(function (DiscordEmbedField $field) {
+                    $field->name('Hull')
+                        ->value(number_format($this->notification->text['hullPercentage'], 2));
+                })->color(DiscordMessage::SUCCESS);
+
+                if ($this->notification->text['hullPercentage'] < 70) {
+                    $embed->color(DiscordMessage::WARNING);
+                }
+
+                if ($this->notification->text['hullPercentage'] < 40) {
+                    $embed->color(DiscordMessage::ERROR);
+                }
+            });
+    }
+}

--- a/src/Notifications/Structures/Discord/SkyhookUnderAttack.php
+++ b/src/Notifications/Structures/Discord/SkyhookUnderAttack.php
@@ -53,7 +53,7 @@ class SkyhookUnderAttack extends AbstractDiscordNotification
 
                 $embed->timestamp($this->notification->timestamp);
                 $embed->color(DiscordMessage::ERROR);
-                $embed->author('SeAT Structure Monitor', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT Structure Monitor', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) {
                     $field->name('Attacker')

--- a/src/Notifications/Structures/Discord/StructureAnchoring.php
+++ b/src/Notifications/Structures/Discord/StructureAnchoring.php
@@ -54,7 +54,7 @@ class StructureAnchoring extends AbstractDiscordNotification
             ->embed(function (DiscordEmbed $embed) {
                 $embed->timestamp($this->notification->timestamp);
                 $embed->color(DiscordMessage::INFO);
-                $embed->author('SeAT Structure Monitor', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT Structure Monitor', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) {
                     $system = MapDenormalize::firstOrNew(

--- a/src/Notifications/Structures/Discord/StructureAnchoring.php
+++ b/src/Notifications/Structures/Discord/StructureAnchoring.php
@@ -96,13 +96,14 @@ class StructureAnchoring extends AbstractDiscordNotification
             })
             ->embed(function (DiscordEmbed $embed) {
                 $embed->field(function (DiscordEmbedField $field) {
-                    $field->name('Remaining Time')
-                        ->value($this->notification->text['timeLeft']);
+                    $field->name('Anchors At (UTC)')
+                        ->value($this->eveDurationToDateTimeString($this->notification->text['timeLeft'], $this->notification->timestamp))
+                        ->long();
                 });
 
                 $embed->field(function (DiscordEmbedField $field) {
-                    $field->name('Vulnerability Time')
-                        ->value($this->notification->text['vulnerableTime']);
+                    $field->name('Vulnerability Window')
+                        ->value($this->eveDurationToString($this->notification->text['vulnerableTime']));
                 });
             })
             ->warning();

--- a/src/Notifications/Structures/Discord/StructureFuelAlert.php
+++ b/src/Notifications/Structures/Discord/StructureFuelAlert.php
@@ -55,7 +55,7 @@ class StructureFuelAlert extends AbstractDiscordNotification
             ->embed(function (DiscordEmbed $embed) {
                 $embed->timestamp($this->notification->timestamp);
                 $embed->color(DiscordMessage::WARNING);
-                $embed->author('SeAT Structure Monitor', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT Structure Monitor', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) {
                     $system = MapDenormalize::find($this->notification->text['solarsystemID']);

--- a/src/Notifications/Structures/Discord/StructureLostArmor.php
+++ b/src/Notifications/Structures/Discord/StructureLostArmor.php
@@ -22,9 +22,14 @@
 
 namespace Seat\Notifications\Notifications\Structures\Discord;
 
+use Illuminate\Support\Collection;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
+use Seat\Eveapi\Models\Universe\UniverseName;
+use Seat\Eveapi\Models\Universe\UniverseStructure;
+use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
+use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
 use Seat\Notifications\Notifications\AbstractDiscordNotification;
 use Seat\Notifications\Services\Discord\Messages\DiscordEmbed;
 use Seat\Notifications\Services\Discord\Messages\DiscordEmbedField;
@@ -36,7 +41,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Structures\Slack
  */
-class StructureLostArmor extends AbstractDiscordNotification
+class StructureLostArmor extends AbstractDiscordNotification implements ExposesRequiredUniverseIds
 {
     use NotificationTools;
 
@@ -47,21 +52,82 @@ class StructureLostArmor extends AbstractDiscordNotification
         $this->notification = $notification;
     }
 
+    public function middleware(): array
+    {
+        return array_merge(
+            parent::middleware(),
+            [new LoadRequiredUniverseIds]
+        );
+    }
+
+    public function getRequiredUniverseIds(): Collection
+    {
+        return collect([
+            $this->notification->text['charID'] ?? null,
+            $this->notification->text['corpLinkData'][2] ?? null,
+            $this->notification->text['allianceID'] ?? null,
+        ])->filter()->unique()->values();
+    }
+
     public function populateMessage(DiscordMessage $message, $notifiable): void
     {
+        $character_id = $this->notification->text['charID'] ?? null;
+        $corporation_id = $this->notification->text['corpLinkData'][2] ?? null;
+        $alliance_id = $this->notification->text['allianceID'] ?? null;
+        $attacker = is_null($character_id) ? null : UniverseName::firstOrNew(
+            ['entity_id' => $character_id],
+            ['category' => 'character', 'name' => trans('web::seat.unknown')]
+        );
+        $corporation = is_null($corporation_id) ? null : UniverseName::firstOrNew(
+            ['entity_id' => $corporation_id],
+            ['category' => 'corporation', 'name' => trans('web::seat.unknown')]
+        );
+        $alliance = is_null($alliance_id) ? null : UniverseName::firstOrNew(
+            ['entity_id' => $alliance_id],
+            ['category' => 'alliance', 'name' => trans('web::seat.unknown')]
+        );
+        $system = MapDenormalize::firstOrNew(
+            ['itemID' => $this->notification->text['solarsystemID']],
+            ['itemName' => trans('web::seat.unknown'), 'security' => 0]
+        );
+        $type = InvType::firstOrNew(
+            ['typeID' => $this->notification->text['structureTypeID']],
+            ['typeName' => trans('web::seat.unknown')]
+        );
+        $structure = UniverseStructure::find($this->notification->text['structureID'] ?? 0);
+        $structure_name = ! is_null($structure) && ! empty($structure->name) ? $structure->name : 'Structure';
+
         $message
             ->content('A Structure lost Armor!')
-            ->embed(function (DiscordEmbed $embed) {
+            ->embed(function (DiscordEmbed $embed) use ($attacker, $character_id, $corporation, $corporation_id, $alliance, $alliance_id, $system, $type, $structure_name) {
                 $embed->timestamp($this->notification->timestamp);
                 $embed->color(DiscordMessage::ERROR);
                 $embed->author('SeAT Structure Monitor', asset('web/img/favicon/apple-icon-180x180.png'));
 
-                $embed->field(function (DiscordEmbedField $field) {
-                    $system = MapDenormalize::firstOrNew(
-                        ['itemID' => $this->notification->text['solarsystemID']],
-                        ['itemName' => trans('web::seat.unknown')]
-                    );
+                if (! is_null($attacker) && ! is_null($character_id)) {
+                    $embed->field(function (DiscordEmbedField $field) use ($attacker, $character_id) {
+                        $field->name('Character')
+                            ->value($this->zKillBoardToDiscordLink('character', $character_id, $attacker->name));
+                    });
+                }
 
+                if (! is_null($corporation) && ! is_null($corporation_id)) {
+                    $corporation_name = $this->notification->text['corpName'] ?? $corporation->name;
+                    $embed->field(function (DiscordEmbedField $field) use ($corporation_id, $corporation_name) {
+                        $field->name('Corporation')
+                            ->value($this->zKillBoardToDiscordLink('corporation', $corporation_id, $corporation_name));
+                    });
+                }
+
+                if (! is_null($alliance) && ! is_null($alliance_id)) {
+                    $alliance_name = $this->notification->text['allianceName'] ?? $alliance->name;
+                    $embed->field(function (DiscordEmbedField $field) use ($alliance_id, $alliance_name) {
+                        $field->name('Alliance')
+                            ->value($this->zKillBoardToDiscordLink('alliance', $alliance_id, $alliance_name));
+                    });
+                }
+
+                $embed->field(function (DiscordEmbedField $field) use ($system) {
                     $field->name('System')
                         ->value(
                             $this->zKillBoardToDiscordLink(
@@ -72,15 +138,24 @@ class StructureLostArmor extends AbstractDiscordNotification
                         );
                 });
 
-                $embed->field(function (DiscordEmbedField $field) {
-                    $type = InvType::firstOrNew(
-                        ['typeID' => $this->notification->text['structureTypeID']],
-                        ['typeName' => trans('web::seat.unknown')]
-                    );
-
-                    $field->name('Structure')
+                $embed->field(function (DiscordEmbedField $field) use ($type, $structure_name) {
+                    $field->name($structure_name)
                         ->value($this->zKillBoardToDiscordLink('ship', $type->typeID, $type->typeName));
                 });
+
+                if (array_key_exists('timeLeft', $this->notification->text)) {
+                    $embed->field(function (DiscordEmbedField $field) {
+                        $field->name('Reinforcement Timer')
+                            ->value($this->eveDurationToDateTimeString($this->notification->text['timeLeft'], $this->notification->timestamp));
+                    });
+                }
+
+                if (array_key_exists('vulnerableTime', $this->notification->text)) {
+                    $embed->field(function (DiscordEmbedField $field) {
+                        $field->name('Vulnerability Window')
+                            ->value($this->eveDurationToString($this->notification->text['vulnerableTime']));
+                    });
+                }
             })
             ->warning();
     }

--- a/src/Notifications/Structures/Discord/StructureLostArmor.php
+++ b/src/Notifications/Structures/Discord/StructureLostArmor.php
@@ -54,7 +54,7 @@ class StructureLostArmor extends AbstractDiscordNotification
             ->embed(function (DiscordEmbed $embed) {
                 $embed->timestamp($this->notification->timestamp);
                 $embed->color(DiscordMessage::ERROR);
-                $embed->author('SeAT Structure Monitor', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT Structure Monitor', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) {
                     $system = MapDenormalize::firstOrNew(

--- a/src/Notifications/Structures/Discord/StructureLostShields.php
+++ b/src/Notifications/Structures/Discord/StructureLostShields.php
@@ -54,7 +54,7 @@ class StructureLostShields extends AbstractDiscordNotification
             ->embed(function (DiscordEmbed $embed) {
                 $embed->timestamp($this->notification->timestamp);
                 $embed->color(DiscordMessage::ERROR);
-                $embed->author('SeAT Structure Monitor', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT Structure Monitor', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) {
                     $system = MapDenormalize::firstOrNew(

--- a/src/Notifications/Structures/Discord/StructureLostShields.php
+++ b/src/Notifications/Structures/Discord/StructureLostShields.php
@@ -22,9 +22,14 @@
 
 namespace Seat\Notifications\Notifications\Structures\Discord;
 
+use Illuminate\Support\Collection;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
+use Seat\Eveapi\Models\Universe\UniverseName;
+use Seat\Eveapi\Models\Universe\UniverseStructure;
+use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
+use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
 use Seat\Notifications\Notifications\AbstractDiscordNotification;
 use Seat\Notifications\Services\Discord\Messages\DiscordEmbed;
 use Seat\Notifications\Services\Discord\Messages\DiscordEmbedField;
@@ -36,7 +41,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Structures\Slack
  */
-class StructureLostShields extends AbstractDiscordNotification
+class StructureLostShields extends AbstractDiscordNotification implements ExposesRequiredUniverseIds
 {
     use NotificationTools;
 
@@ -47,21 +52,82 @@ class StructureLostShields extends AbstractDiscordNotification
         $this->notification = $notification;
     }
 
+    public function middleware(): array
+    {
+        return array_merge(
+            parent::middleware(),
+            [new LoadRequiredUniverseIds]
+        );
+    }
+
+    public function getRequiredUniverseIds(): Collection
+    {
+        return collect([
+            $this->notification->text['charID'] ?? null,
+            $this->notification->text['corpLinkData'][2] ?? null,
+            $this->notification->text['allianceID'] ?? null,
+        ])->filter()->unique()->values();
+    }
+
     public function populateMessage(DiscordMessage $message, $notifiable): void
     {
+        $character_id = $this->notification->text['charID'] ?? null;
+        $corporation_id = $this->notification->text['corpLinkData'][2] ?? null;
+        $alliance_id = $this->notification->text['allianceID'] ?? null;
+        $attacker = is_null($character_id) ? null : UniverseName::firstOrNew(
+            ['entity_id' => $character_id],
+            ['category' => 'character', 'name' => trans('web::seat.unknown')]
+        );
+        $corporation = is_null($corporation_id) ? null : UniverseName::firstOrNew(
+            ['entity_id' => $corporation_id],
+            ['category' => 'corporation', 'name' => trans('web::seat.unknown')]
+        );
+        $alliance = is_null($alliance_id) ? null : UniverseName::firstOrNew(
+            ['entity_id' => $alliance_id],
+            ['category' => 'alliance', 'name' => trans('web::seat.unknown')]
+        );
+        $system = MapDenormalize::firstOrNew(
+            ['itemID' => $this->notification->text['solarsystemID']],
+            ['itemName' => trans('web::seat.unknown'), 'security' => 0]
+        );
+        $type = InvType::firstOrNew(
+            ['typeID' => $this->notification->text['structureTypeID']],
+            ['typeName' => trans('web::seat.unknown')]
+        );
+        $structure = UniverseStructure::find($this->notification->text['structureID'] ?? 0);
+        $structure_name = ! is_null($structure) && ! empty($structure->name) ? $structure->name : 'Structure';
+
         $message
             ->content('A Structure lost Shield!')
-            ->embed(function (DiscordEmbed $embed) {
+            ->embed(function (DiscordEmbed $embed) use ($attacker, $character_id, $corporation, $corporation_id, $alliance, $alliance_id, $system, $type, $structure_name) {
                 $embed->timestamp($this->notification->timestamp);
                 $embed->color(DiscordMessage::ERROR);
                 $embed->author('SeAT Structure Monitor', asset('web/img/favicon/apple-icon-180x180.png'));
 
-                $embed->field(function (DiscordEmbedField $field) {
-                    $system = MapDenormalize::firstOrNew(
-                        ['itemID' => $this->notification->text['solarsystemID']],
-                        ['itemName' => trans('web::seat.unknown')]
-                    );
+                if (! is_null($attacker) && ! is_null($character_id)) {
+                    $embed->field(function (DiscordEmbedField $field) use ($attacker, $character_id) {
+                        $field->name('Character')
+                            ->value($this->zKillBoardToDiscordLink('character', $character_id, $attacker->name));
+                    });
+                }
 
+                if (! is_null($corporation) && ! is_null($corporation_id)) {
+                    $corporation_name = $this->notification->text['corpName'] ?? $corporation->name;
+                    $embed->field(function (DiscordEmbedField $field) use ($corporation_id, $corporation_name) {
+                        $field->name('Corporation')
+                            ->value($this->zKillBoardToDiscordLink('corporation', $corporation_id, $corporation_name));
+                    });
+                }
+
+                if (! is_null($alliance) && ! is_null($alliance_id)) {
+                    $alliance_name = $this->notification->text['allianceName'] ?? $alliance->name;
+                    $embed->field(function (DiscordEmbedField $field) use ($alliance_id, $alliance_name) {
+                        $field->name('Alliance')
+                            ->value($this->zKillBoardToDiscordLink('alliance', $alliance_id, $alliance_name));
+                    });
+                }
+
+                $embed->field(function (DiscordEmbedField $field) use ($system) {
                     $field->name('System')
                         ->value(
                             $this->zKillBoardToDiscordLink(
@@ -72,15 +138,24 @@ class StructureLostShields extends AbstractDiscordNotification
                         );
                 });
 
-                $embed->field(function (DiscordEmbedField $field) {
-                    $type = InvType::firstOrNew(
-                        ['typeID' => $this->notification->text['structureTypeID']],
-                        ['typeName' => trans('web::seat.unknown')]
-                    );
-
-                    $field->name('Structure')
+                $embed->field(function (DiscordEmbedField $field) use ($type, $structure_name) {
+                    $field->name($structure_name)
                         ->value($this->zKillBoardToDiscordLink('ship', $type->typeID, $type->typeName));
                 });
+
+                if (array_key_exists('timeLeft', $this->notification->text)) {
+                    $embed->field(function (DiscordEmbedField $field) {
+                        $field->name('Reinforcement Timer')
+                            ->value($this->eveDurationToDateTimeString($this->notification->text['timeLeft'], $this->notification->timestamp));
+                    });
+                }
+
+                if (array_key_exists('vulnerableTime', $this->notification->text)) {
+                    $embed->field(function (DiscordEmbedField $field) {
+                        $field->name('Vulnerability Window')
+                            ->value($this->eveDurationToString($this->notification->text['vulnerableTime']));
+                    });
+                }
             })
             ->warning();
     }

--- a/src/Notifications/Structures/Discord/StructureServicesOffline.php
+++ b/src/Notifications/Structures/Discord/StructureServicesOffline.php
@@ -54,7 +54,7 @@ class StructureServicesOffline extends AbstractDiscordNotification
             ->embed(function (DiscordEmbed $embed) {
                 $embed->timestamp($this->notification->timestamp);
                 $embed->color(DiscordMessage::WARNING);
-                $embed->author('SeAT Structure Monitor', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT Structure Monitor', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) {
                     $system = MapDenormalize::find($this->notification->text['solarsystemID']);

--- a/src/Notifications/Structures/Discord/StructureUnanchoring.php
+++ b/src/Notifications/Structures/Discord/StructureUnanchoring.php
@@ -54,7 +54,7 @@ class StructureUnanchoring extends AbstractDiscordNotification
             ->embed(function (DiscordEmbed $embed) {
                 $embed->timestamp($this->notification->timestamp);
                 $embed->color(DiscordMessage::INFO);
-                $embed->author('SeAT Structure Monitor', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT Structure Monitor', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) {
                     $system = MapDenormalize::firstOrNew(

--- a/src/Notifications/Structures/Discord/StructureUnanchoring.php
+++ b/src/Notifications/Structures/Discord/StructureUnanchoring.php
@@ -96,8 +96,9 @@ class StructureUnanchoring extends AbstractDiscordNotification
             })
             ->embed(function (DiscordEmbed $embed) {
                 $embed->field(function (DiscordEmbedField $field) {
-                    $field->name('Remaining Time')
-                        ->value($this->notification->text['timeLeft']);
+                    $field->name('Unanchors At (UTC)')
+                        ->value($this->eveDurationToDateTimeString($this->notification->text['timeLeft'], $this->notification->timestamp))
+                        ->long();
                 });
             })
             ->warning();

--- a/src/Notifications/Structures/Discord/StructureUnderAttack.php
+++ b/src/Notifications/Structures/Discord/StructureUnderAttack.php
@@ -55,7 +55,7 @@ class StructureUnderAttack extends AbstractDiscordNotification
             ->embed(function (DiscordEmbed $embed) {
                 $embed->timestamp($this->notification->timestamp);
                 $embed->color(DiscordMessage::ERROR);
-                $embed->author('SeAT Structure Monitor', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT Structure Monitor', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) {
                     $field->name('Attacker')

--- a/src/Notifications/Structures/Discord/StructureUnderAttack.php
+++ b/src/Notifications/Structures/Discord/StructureUnderAttack.php
@@ -68,8 +68,8 @@ class StructureUnderAttack extends AbstractDiscordNotification
                         );
                 });
 
-                if (array_key_exists('aggressorAllianceID', $this->notification->text) && ! is_null(
-                    $this->notification->text['aggressorAllianceID']
+                if (array_key_exists('allianceID', $this->notification->text) && ! is_null(
+                    $this->notification->text['allianceID']
                     )) {
                     $embed->field(function (DiscordEmbedField $field) {
                         $field->name('Alliance')

--- a/src/Notifications/Structures/Discord/StructureUnderAttack.php
+++ b/src/Notifications/Structures/Discord/StructureUnderAttack.php
@@ -22,10 +22,14 @@
 
 namespace Seat\Notifications\Notifications\Structures\Discord;
 
+use Illuminate\Support\Collection;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
+use Seat\Eveapi\Models\Universe\UniverseName;
 use Seat\Eveapi\Models\Universe\UniverseStructure;
+use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
+use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
 use Seat\Notifications\Notifications\AbstractDiscordNotification;
 use Seat\Notifications\Services\Discord\Messages\DiscordEmbed;
 use Seat\Notifications\Services\Discord\Messages\DiscordEmbedField;
@@ -37,7 +41,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Structures
  */
-class StructureUnderAttack extends AbstractDiscordNotification
+class StructureUnderAttack extends AbstractDiscordNotification implements ExposesRequiredUniverseIds
 {
     use NotificationTools;
 
@@ -48,17 +52,48 @@ class StructureUnderAttack extends AbstractDiscordNotification
         $this->notification = $notification;
     }
 
+    public function middleware(): array
+    {
+        return array_merge(
+            parent::middleware(),
+            [new LoadRequiredUniverseIds]
+        );
+    }
+
+    public function getRequiredUniverseIds(): Collection
+    {
+        return collect([
+            $this->notification->text['charID'] ?? null,
+        ])->filter()->unique()->values();
+    }
+
     public function populateMessage(DiscordMessage $message, $notifiable): void
     {
+        $attacker = UniverseName::firstOrNew(
+            ['entity_id' => $this->notification->text['charID']],
+            ['category' => 'character', 'name' => trans('web::seat.unknown')]
+        );
+
         $message
             ->content('A structure is under attack!')
-            ->embed(function (DiscordEmbed $embed) {
+            ->embed(function (DiscordEmbed $embed) use ($attacker) {
                 $embed->timestamp($this->notification->timestamp);
                 $embed->color(DiscordMessage::ERROR);
                 $embed->author('SeAT Structure Monitor', asset('web/img/favicon/apple-icon-180x180.png'));
 
+                $embed->field(function (DiscordEmbedField $field) use ($attacker) {
+                    $field->name('Character')
+                        ->value(
+                            $this->zKillBoardToDiscordLink(
+                                'character',
+                                $this->notification->text['charID'],
+                                $attacker->name
+                            )
+                        );
+                });
+
                 $embed->field(function (DiscordEmbedField $field) {
-                    $field->name('Attacker')
+                    $field->name('Corporation')
                         ->value(
                             $this->zKillBoardToDiscordLink(
                                 'corporation',

--- a/src/Notifications/Structures/Discord/StructureWentHighPower.php
+++ b/src/Notifications/Structures/Discord/StructureWentHighPower.php
@@ -56,7 +56,7 @@ class StructureWentHighPower extends AbstractDiscordNotification
             ->embed(function (DiscordEmbed $embed) {
                 $embed->timestamp($this->notification->timestamp);
                 $embed->color(DiscordMessage::SUCCESS);
-                $embed->author('SeAT Structure Monitor', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT Structure Monitor', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) {
                     $system = MapDenormalize::firstOrNew(

--- a/src/Notifications/Structures/Discord/StructureWentLowPower.php
+++ b/src/Notifications/Structures/Discord/StructureWentLowPower.php
@@ -54,7 +54,7 @@ class StructureWentLowPower extends AbstractDiscordNotification
             ->embed(function (DiscordEmbed $embed) {
                 $embed->timestamp($this->notification->timestamp);
                 $embed->color(DiscordMessage::ERROR);
-                $embed->author('SeAT Structure Monitor', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT Structure Monitor', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) {
                     $system = MapDenormalize::firstOrNew(

--- a/src/Notifications/Structures/Discord/TowerAlertMsg.php
+++ b/src/Notifications/Structures/Discord/TowerAlertMsg.php
@@ -54,7 +54,7 @@ class TowerAlertMsg extends AbstractDiscordNotification
             ->embed(function (DiscordEmbed $embed) {
                 $embed->timestamp($this->notification->timestamp);
                 $embed->color(DiscordMessage::ERROR);
-                $embed->author('SeAT Structure Monitor', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT Structure Monitor', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) {
                     $field->name('Character')

--- a/src/Notifications/Structures/Discord/TowerResourceAlertMsg.php
+++ b/src/Notifications/Structures/Discord/TowerResourceAlertMsg.php
@@ -56,7 +56,7 @@ class TowerResourceAlertMsg extends AbstractDiscordNotification
             ->embed(function (DiscordEmbed $embed) {
                 $embed->timestamp($this->notification->timestamp);
                 $embed->color(DiscordMessage::WARNING);
-                $embed->author('SeAT Structure Monitor', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT Structure Monitor', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) {
                     $system = MapDenormalize::firstOrNew(

--- a/src/Notifications/Structures/Discord/TowerResourceAlertMsg.php
+++ b/src/Notifications/Structures/Discord/TowerResourceAlertMsg.php
@@ -22,11 +22,13 @@
 
 namespace Seat\Notifications\Notifications\Structures\Discord;
 
-use Seat\Eveapi\Models\Alliances\Alliance;
+use Illuminate\Support\Collection;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
 use Seat\Eveapi\Models\Universe\UniverseName;
+use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
+use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
 use Seat\Notifications\Notifications\AbstractDiscordNotification;
 use Seat\Notifications\Services\Discord\Messages\DiscordEmbed;
 use Seat\Notifications\Services\Discord\Messages\DiscordEmbedField;
@@ -38,7 +40,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Structures
  */
-class TowerResourceAlertMsg extends AbstractDiscordNotification
+class TowerResourceAlertMsg extends AbstractDiscordNotification implements ExposesRequiredUniverseIds
 {
     use NotificationTools;
 
@@ -47,6 +49,22 @@ class TowerResourceAlertMsg extends AbstractDiscordNotification
     public function __construct(CharacterNotification $notification)
     {
         $this->notification = $notification;
+    }
+
+    public function middleware(): array
+    {
+        return array_merge(
+            parent::middleware(),
+            [new LoadRequiredUniverseIds]
+        );
+    }
+
+    public function getRequiredUniverseIds(): Collection
+    {
+        return collect([
+            $this->notification->text['corpID'] ?? null,
+            $this->notification->text['allianceID'] ?? null,
+        ])->filter()->unique()->values();
     }
 
     public function populateMessage(DiscordMessage $message, $notifiable): void
@@ -95,17 +113,20 @@ class TowerResourceAlertMsg extends AbstractDiscordNotification
                 });
 
                 $embed->field(function (DiscordEmbedField $field) {
-                    $corporation = UniverseName::find($this->notification->text['corpID']);
+                    $corporation = UniverseName::firstOrNew(
+                        ['entity_id' => $this->notification->text['corpID']],
+                        ['category' => 'corporation', 'name' => trans('web::seat.unknown')]
+                    );
 
                     $field->name('Corporation')
-                        ->value($corporation?->name ?? trans('web::seat.unknown'));
+                        ->value($corporation->name);
                 });
 
                 if (array_key_exists('allianceID', $this->notification->text) && ! is_null($this->notification->text['allianceID'])) {
                     $embed->field(function (DiscordEmbedField $field) {
-                        $alliance = Alliance::firstOrNew(
-                            ['alliance_id' => $this->notification->text['allianceID']],
-                            ['name' => trans('web::seat.unknown')]
+                        $alliance = UniverseName::firstOrNew(
+                            ['entity_id' => $this->notification->text['allianceID']],
+                            ['category' => 'alliance', 'name' => trans('web::seat.unknown')]
                         );
 
                         $field->name('Alliance')

--- a/src/Notifications/Structures/Mail/SkyhookUnderAttack.php
+++ b/src/Notifications/Structures/Mail/SkyhookUnderAttack.php
@@ -23,12 +23,16 @@
 namespace Seat\Notifications\Notifications\Structures\Mail;
 
 use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Support\Collection;
 use Seat\Eveapi\Models\Character\CharacterNotification;
+use Seat\Eveapi\Models\Universe\UniverseName;
+use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
+use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
 use Seat\Notifications\Notifications\AbstractMailNotification;
 use Seat\Notifications\Notifications\Structures\Traits\SkyhookNotificationTools;
 use Seat\Notifications\Traits\NotificationTools;
 
-class SkyhookUnderAttack extends AbstractMailNotification
+class SkyhookUnderAttack extends AbstractMailNotification implements ExposesRequiredUniverseIds
 {
     use NotificationTools;
     use SkyhookNotificationTools;
@@ -40,8 +44,27 @@ class SkyhookUnderAttack extends AbstractMailNotification
         $this->notification = $notification;
     }
 
+    public function middleware(): array
+    {
+        return array_merge(
+            parent::middleware(),
+            [new LoadRequiredUniverseIds]
+        );
+    }
+
+    public function getRequiredUniverseIds(): Collection
+    {
+        return collect([
+            $this->notification->text['charID'] ?? null,
+        ])->filter()->unique()->values();
+    }
+
     public function toMail($notifiable)
     {
+        $attacker = UniverseName::firstOrNew(
+            ['entity_id' => $this->notification->text['charID']],
+            ['category' => 'character', 'name' => trans('web::seat.unknown')]
+        );
         $system = $this->getSkyhookSystem();
         $planet = $this->getSkyhookPlanet();
         $type = $this->getSkyhookType();
@@ -61,9 +84,10 @@ class SkyhookUnderAttack extends AbstractMailNotification
                 $this->notification->text['hullPercentage']
             ))
             ->line(sprintf(
-                'at %s in %s by %s',
+                'at %s in %s by %s (%s)',
                 $planet->itemName,
                 $system->itemName,
+                $attacker->name,
                 $this->notification->text['corpName']
             ));
 

--- a/src/Notifications/Structures/Mail/SkyhookUnderAttack.php
+++ b/src/Notifications/Structures/Mail/SkyhookUnderAttack.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Notifications\Notifications\Structures\Mail;
+
+use Illuminate\Notifications\Messages\MailMessage;
+use Seat\Eveapi\Models\Character\CharacterNotification;
+use Seat\Notifications\Notifications\AbstractMailNotification;
+use Seat\Notifications\Notifications\Structures\Traits\SkyhookNotificationTools;
+use Seat\Notifications\Traits\NotificationTools;
+
+class SkyhookUnderAttack extends AbstractMailNotification
+{
+    use NotificationTools;
+    use SkyhookNotificationTools;
+
+    private CharacterNotification $notification;
+
+    public function __construct(CharacterNotification $notification)
+    {
+        $this->notification = $notification;
+    }
+
+    public function toMail($notifiable)
+    {
+        $system = $this->getSkyhookSystem();
+        $planet = $this->getSkyhookPlanet();
+        $type = $this->getSkyhookType();
+
+        $mail = (new MailMessage)
+            ->subject('Skyhook Under Attack Notification')
+            ->line('A skyhook is under attack!')
+            ->line(sprintf(
+                'Skyhook (%s, "%s") attacked',
+                $this->getSkyhookName(),
+                $type->typeName
+            ))
+            ->line(sprintf(
+                '(%d shield, %d armor, %d hull)',
+                $this->notification->text['shieldPercentage'],
+                $this->notification->text['armorPercentage'],
+                $this->notification->text['hullPercentage']
+            ))
+            ->line(sprintf(
+                'at %s in %s by %s',
+                $planet->itemName,
+                $system->itemName,
+                $this->notification->text['corpName']
+            ));
+
+        if (array_key_exists('allianceName', $this->notification->text) && ! empty($this->notification->text['allianceName'])) {
+            $mail->line(sprintf('Alliance: %s', $this->notification->text['allianceName']));
+        }
+
+        return $mail;
+    }
+
+    public function toArray($notifiable)
+    {
+        return $this->notification->text;
+    }
+}

--- a/src/Notifications/Structures/Mail/StructureUnderAttack.php
+++ b/src/Notifications/Structures/Mail/StructureUnderAttack.php
@@ -23,10 +23,14 @@
 namespace Seat\Notifications\Notifications\Structures\Mail;
 
 use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Support\Collection;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
+use Seat\Eveapi\Models\Universe\UniverseName;
 use Seat\Eveapi\Models\Universe\UniverseStructure;
+use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
+use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
 use Seat\Notifications\Notifications\AbstractMailNotification;
 use Seat\Notifications\Traits\NotificationTools;
 
@@ -35,7 +39,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Structures
  */
-class StructureUnderAttack extends AbstractMailNotification
+class StructureUnderAttack extends AbstractMailNotification implements ExposesRequiredUniverseIds
 {
     use NotificationTools;
 
@@ -54,12 +58,31 @@ class StructureUnderAttack extends AbstractMailNotification
         $this->notification = $notification;
     }
 
+    public function middleware(): array
+    {
+        return array_merge(
+            parent::middleware(),
+            [new LoadRequiredUniverseIds]
+        );
+    }
+
+    public function getRequiredUniverseIds(): Collection
+    {
+        return collect([
+            $this->notification->text['charID'] ?? null,
+        ])->filter()->unique()->values();
+    }
+
     /**
      * @param  $notifiable
      * @return \Illuminate\Notifications\Messages\MailMessage
      */
     public function toMail($notifiable)
     {
+        $attacker = UniverseName::firstOrNew(
+            ['entity_id' => $this->notification->text['charID']],
+            ['category' => 'character', 'name' => trans('web::seat.unknown')]
+        );
         $system = MapDenormalize::find($this->notification->text['solarsystemID']);
         $structure = UniverseStructure::find($this->notification->text['structureID']);
         $type = InvType::find($this->notification->text['structureShowInfoData'][1]);
@@ -82,8 +105,9 @@ class StructureUnderAttack extends AbstractMailNotification
                     $this->notification->text['hullPercentage'])
             )
             ->line(
-                sprintf('in %s by %s',
+                sprintf('in %s by %s (%s)',
                     $system->itemName,
+                    $attacker->name,
                     $this->notification->text['corpName'])
             );
     }

--- a/src/Notifications/Structures/Mail/TowerResourceAlertMsg.php
+++ b/src/Notifications/Structures/Mail/TowerResourceAlertMsg.php
@@ -23,11 +23,13 @@
 namespace Seat\Notifications\Notifications\Structures\Mail;
 
 use Illuminate\Notifications\Messages\MailMessage;
-use Seat\Eveapi\Models\Alliances\Alliance;
+use Illuminate\Support\Collection;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
 use Seat\Eveapi\Models\Universe\UniverseName;
+use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
+use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
 use Seat\Notifications\Notifications\AbstractMailNotification;
 use Seat\Notifications\Traits\NotificationTools;
 
@@ -36,7 +38,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Structures
  */
-class TowerResourceAlertMsg extends AbstractMailNotification
+class TowerResourceAlertMsg extends AbstractMailNotification implements ExposesRequiredUniverseIds
 {
     use NotificationTools;
 
@@ -45,6 +47,22 @@ class TowerResourceAlertMsg extends AbstractMailNotification
     public function __construct(CharacterNotification $notification)
     {
         $this->notification = $notification;
+    }
+
+    public function middleware(): array
+    {
+        return array_merge(
+            parent::middleware(),
+            [new LoadRequiredUniverseIds]
+        );
+    }
+
+    public function getRequiredUniverseIds(): Collection
+    {
+        return collect([
+            $this->notification->text['corpID'] ?? null,
+            $this->notification->text['allianceID'] ?? null,
+        ])->filter()->unique()->values();
     }
 
     public function toMail($notifiable)
@@ -61,7 +79,10 @@ class TowerResourceAlertMsg extends AbstractMailNotification
             ['typeID' => $this->notification->text['typeID']],
             ['typeName' => trans('web::seat.unknown')]
         );
-        $corporation = UniverseName::find($this->notification->text['corpID']);
+        $corporation = UniverseName::firstOrNew(
+            ['entity_id' => $this->notification->text['corpID']],
+            ['category' => 'corporation', 'name' => trans('web::seat.unknown')]
+        );
         $alliance = $this->notification->text['allianceID'] ?? null;
         $mail = (new MailMessage)
             ->subject('Tower Resource Alert Notification')
@@ -74,19 +95,14 @@ class TowerResourceAlertMsg extends AbstractMailNotification
                 number_format($system->security, 2)
             ));
 
-        if (! is_null($corporation)) {
-            $mail->line(sprintf('Corporation: %s', $corporation->name));
-        }
+        $mail->line(sprintf('Corporation: %s', $corporation->name));
 
         if (! is_null($alliance)) {
-            $alliance_name = Alliance::firstOrNew(
-                ['alliance_id' => $alliance],
-                ['name' => trans('web::seat.unknown')]
+            $alliance_name = UniverseName::firstOrNew(
+                ['entity_id' => $alliance],
+                ['category' => 'alliance', 'name' => trans('web::seat.unknown')]
             );
-
-            if (! is_null($alliance_name)) {
-                $mail->line(sprintf('Alliance: %s', $alliance_name->name));
-            }
+            $mail->line(sprintf('Alliance: %s', $alliance_name->name));
         }
 
         foreach ($this->notification->text['wants'] ?? [] as $item) {

--- a/src/Notifications/Structures/Slack/AllAnchoringMsg.php
+++ b/src/Notifications/Structures/Slack/AllAnchoringMsg.php
@@ -23,10 +23,13 @@
 namespace Seat\Notifications\Notifications\Structures\Slack;
 
 use Illuminate\Notifications\Messages\SlackMessage;
+use Illuminate\Support\Collection;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
 use Seat\Eveapi\Models\Universe\UniverseName;
+use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
+use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 
@@ -35,7 +38,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Structures\Slack
  */
-class AllAnchoringMsg extends AbstractSlackNotification
+class AllAnchoringMsg extends AbstractSlackNotification implements ExposesRequiredUniverseIds
 {
     use NotificationTools;
 
@@ -54,6 +57,21 @@ class AllAnchoringMsg extends AbstractSlackNotification
         $this->notification = $notification;
     }
 
+    public function middleware(): array
+    {
+        return array_merge(
+            parent::middleware(),
+            [new LoadRequiredUniverseIds]
+        );
+    }
+
+    public function getRequiredUniverseIds(): Collection
+    {
+        return collect([
+            $this->notification->text['corpID'] ?? null,
+        ])->filter()->unique()->values();
+    }
+
     /**
      * @param  $notifiable
      * @return \Illuminate\Notifications\Messages\SlackMessage
@@ -66,7 +84,10 @@ class AllAnchoringMsg extends AbstractSlackNotification
             ->attachment(function ($attachment) {
                 $attachment
                     ->field(function ($field) {
-                        $system = MapDenormalize::find($this->notification->text['solarSystemID']);
+                        $system = MapDenormalize::firstOrNew(
+                            ['itemID' => $this->notification->text['solarSystemID']],
+                            ['itemName' => trans('web::seat.unknown'), 'security' => 0]
+                        );
 
                         $field->title('System')
                             ->content(
@@ -77,7 +98,10 @@ class AllAnchoringMsg extends AbstractSlackNotification
                             ));
                     })
                     ->field(function ($field) {
-                        $moon = MapDenormalize::find($this->notification->text['moonID']);
+                        $moon = MapDenormalize::firstOrNew(
+                            ['itemID' => $this->notification->text['moonID']],
+                            ['itemName' => trans('web::seat.unknown')]
+                        );
 
                         $field->title('Moon')
                             ->content($moon->itemName);
@@ -88,14 +112,17 @@ class AllAnchoringMsg extends AbstractSlackNotification
                     ->field(function ($field) {
                         $corporation = UniverseName::firstOrNew(
                             ['entity_id' => $this->notification->text['corpID']],
-                            ['name' => trans('web::seat.unkown')]
+                            ['category' => 'corporation', 'name' => trans('web::seat.unknown')]
                         );
 
                         $field->title('Corporation')
-                            ->content($corporation->name);
+                            ->content($this->zKillBoardToSlackLink('corporation', $corporation->entity_id, $corporation->name));
                     })
                     ->field(function ($field) {
-                        $type = InvType::find($this->notification->text['typeID']);
+                        $type = InvType::firstOrNew(
+                            ['typeID' => $this->notification->text['typeID']],
+                            ['typeName' => trans('web::seat.unknown')]
+                        );
 
                         $field->title('Structure')
                             ->content(

--- a/src/Notifications/Structures/Slack/OrbitalAttacked.php
+++ b/src/Notifications/Structures/Slack/OrbitalAttacked.php
@@ -59,20 +59,35 @@ class OrbitalAttacked extends AbstractSlackNotification
      */
     public function toSlack($notifiable)
     {
+        $aggressor_character = UniverseName::firstOrNew(
+            ['entity_id' => $this->notification->text['aggressorID']],
+            ['category' => 'character', 'name' => trans('web::seat.unknown')]
+        );
+        $aggressor_corporation = UniverseName::firstOrNew(
+            ['entity_id' => $this->notification->text['aggressorCorpID']],
+            ['category' => 'corporation', 'name' => trans('web::seat.unknown')]
+        );
+
         return (new SlackMessage)
             ->content('A customs office is under attack!')
             ->from('SeAT Structure Monitor')
-            ->attachment(function ($attachment) {
-                $attachment->field(function ($field) {
-                    $field->title('Attacker')
+            ->attachment(function ($attachment) use ($aggressor_character, $aggressor_corporation) {
+                $attachment->field(function ($field) use ($aggressor_character) {
+                    $field->title('Character')
                         ->content(
                             $this->zKillBoardToSlackLink(
+                                'character',
+                                $this->notification->text['aggressorID'],
+                                $aggressor_character->name
+                            ));
+                    })
+                    ->field(function ($field) use ($aggressor_corporation) {
+                        $field->title('Corporation')
+                            ->content(
+                                $this->zKillBoardToSlackLink(
                                 'corporation',
                                 $this->notification->text['aggressorCorpID'],
-                                UniverseName::firstOrNew(
-                                    ['entity_id' => $this->notification->text['aggressorCorpID']],
-                                    ['category' => 'corporation', 'name' => trans('web::seat.unknown')])
-                                ->name
+                                $aggressor_corporation->name
                             ));
                     })
                     ->field(function ($field) {

--- a/src/Notifications/Structures/Slack/OrbitalAttacked.php
+++ b/src/Notifications/Structures/Slack/OrbitalAttacked.php
@@ -23,9 +23,12 @@
 namespace Seat\Notifications\Notifications\Structures\Slack;
 
 use Illuminate\Notifications\Messages\SlackMessage;
+use Illuminate\Support\Collection;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
 use Seat\Eveapi\Models\Universe\UniverseName;
+use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
+use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 
@@ -34,7 +37,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Structures\Slack
  */
-class OrbitalAttacked extends AbstractSlackNotification
+class OrbitalAttacked extends AbstractSlackNotification implements ExposesRequiredUniverseIds
 {
     use NotificationTools;
 
@@ -51,6 +54,23 @@ class OrbitalAttacked extends AbstractSlackNotification
     public function __construct(CharacterNotification $notification)
     {
         $this->notification = $notification;
+    }
+
+    public function middleware(): array
+    {
+        return array_merge(
+            parent::middleware(),
+            [new LoadRequiredUniverseIds]
+        );
+    }
+
+    public function getRequiredUniverseIds(): Collection
+    {
+        return collect([
+            $this->notification->text['aggressorID'] ?? null,
+            $this->notification->text['aggressorCorpID'] ?? null,
+            $this->notification->text['aggressorAllianceID'] ?? null,
+        ])->filter()->unique()->values();
     }
 
     /**

--- a/src/Notifications/Structures/Slack/OrbitalReinforced.php
+++ b/src/Notifications/Structures/Slack/OrbitalReinforced.php
@@ -1,0 +1,146 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Notifications\Notifications\Structures\Slack;
+
+use Illuminate\Notifications\Messages\SlackMessage;
+use Illuminate\Support\Collection;
+use Seat\Eveapi\Models\Character\CharacterNotification;
+use Seat\Eveapi\Models\Sde\InvType;
+use Seat\Eveapi\Models\Sde\MapDenormalize;
+use Seat\Eveapi\Models\Universe\UniverseName;
+use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
+use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
+use Seat\Notifications\Traits\NotificationTools;
+
+class OrbitalReinforced extends AbstractSlackNotification implements ExposesRequiredUniverseIds
+{
+    use NotificationTools;
+
+    private CharacterNotification $notification;
+
+    public function __construct(CharacterNotification $notification)
+    {
+        $this->notification = $notification;
+    }
+
+    public function middleware(): array
+    {
+        return array_merge(
+            parent::middleware(),
+            [new LoadRequiredUniverseIds]
+        );
+    }
+
+    public function getRequiredUniverseIds(): Collection
+    {
+        return collect([
+            $this->notification->text['aggressorID'] ?? null,
+            $this->notification->text['aggressorCorpID'] ?? null,
+            $this->notification->text['aggressorAllianceID'] ?? null,
+        ])->filter()->unique()->values();
+    }
+
+    public function toSlack($notifiable)
+    {
+        $aggressor_character = UniverseName::firstOrNew(
+            ['entity_id' => $this->notification->text['aggressorID']],
+            ['category' => 'character', 'name' => trans('web::seat.unknown')]
+        );
+        $aggressor_corporation = UniverseName::firstOrNew(
+            ['entity_id' => $this->notification->text['aggressorCorpID']],
+            ['category' => 'corporation', 'name' => trans('web::seat.unknown')]
+        );
+        $type = InvType::firstOrNew(
+            ['typeID' => $this->notification->text['typeID']],
+            ['typeName' => trans('web::seat.unknown')]
+        );
+
+        return (new SlackMessage)
+            ->content('A customs office has been reinforced!')
+            ->from('SeAT Structure Monitor')
+            ->attachment(function ($attachment) use ($aggressor_character, $aggressor_corporation) {
+                $attachment->field(function ($field) use ($aggressor_character) {
+                    $field->title('Character')
+                        ->content($this->zKillBoardToSlackLink(
+                            'character',
+                            $this->notification->text['aggressorID'],
+                            $aggressor_character->name
+                        ));
+                })->field(function ($field) use ($aggressor_corporation) {
+                    $field->title('Corporation')
+                        ->content($this->zKillBoardToSlackLink(
+                            'corporation',
+                            $this->notification->text['aggressorCorpID'],
+                            $aggressor_corporation->name
+                        ));
+                });
+
+                if (array_key_exists('aggressorAllianceID', $this->notification->text) && ! is_null($this->notification->text['aggressorAllianceID'])) {
+                    $attachment->field(function ($field) {
+                        $field->title('Alliance')
+                            ->content($this->zKillBoardToSlackLink(
+                                'alliance',
+                                $this->notification->text['aggressorAllianceID'],
+                                UniverseName::firstOrNew(
+                                    ['entity_id' => $this->notification->text['aggressorAllianceID']],
+                                    ['category' => 'alliance', 'name' => trans('web::seat.unknown')]
+                                )->name
+                            ));
+                    });
+                }
+            })
+            ->attachment(function ($attachment) use ($type) {
+                $attachment->field(function ($field) {
+                    $system = MapDenormalize::find($this->notification->text['solarSystemID']);
+
+                    $field->title('System')
+                        ->content($this->zKillBoardToSlackLink(
+                            'system',
+                            $system->itemID,
+                            $system->itemName . ' (' . number_format($system->security, 2) . ')'
+                        ));
+                })->field(function ($field) {
+                    $planet = MapDenormalize::find($this->notification->text['planetID']);
+
+                    $field->title('Planet')
+                        ->content($this->zKillBoardToSlackLink(
+                            'location',
+                            $planet->itemID,
+                            $planet->itemName
+                        ));
+                })->field(function ($field) use ($type) {
+                    $field->title('Structure')
+                        ->content($this->zKillBoardToSlackLink('ship', $type->typeID, $type->typeName));
+                });
+            })
+            ->attachment(function ($attachment) {
+                $attachment->field(function ($field) {
+                    $field->title('Reinforcement Exit (UTC)')
+                        ->content($this->mssqlTimestampToDate($this->notification->text['reinforceExitTime'])
+                            ->setTimezone('UTC')
+                            ->format('Y.m.d H:i:s'));
+                })->color('warning');
+            });
+    }
+}

--- a/src/Notifications/Structures/Slack/OwnershipTransferred.php
+++ b/src/Notifications/Structures/Slack/OwnershipTransferred.php
@@ -23,10 +23,13 @@
 namespace Seat\Notifications\Notifications\Structures\Slack;
 
 use Illuminate\Notifications\Messages\SlackMessage;
+use Illuminate\Support\Collection;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
 use Seat\Eveapi\Models\Universe\UniverseName;
+use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
+use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 
@@ -35,7 +38,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Structures
  */
-class OwnershipTransferred extends AbstractSlackNotification
+class OwnershipTransferred extends AbstractSlackNotification implements ExposesRequiredUniverseIds
 {
     use NotificationTools;
 
@@ -54,6 +57,22 @@ class OwnershipTransferred extends AbstractSlackNotification
         $this->notification = $notification;
     }
 
+    public function middleware(): array
+    {
+        return array_merge(
+            parent::middleware(),
+            [new LoadRequiredUniverseIds]
+        );
+    }
+
+    public function getRequiredUniverseIds(): Collection
+    {
+        return collect([
+            $this->notification->text['oldOwnerCorpID'] ?? null,
+            $this->notification->text['newOwnerCorpID'] ?? null,
+        ])->filter()->unique()->values();
+    }
+
     /**
      * @param  $notifiable
      * @return \Illuminate\Notifications\Messages\SlackMessage
@@ -65,7 +84,10 @@ class OwnershipTransferred extends AbstractSlackNotification
             ->from('SeAT Structure Monitor')
             ->attachment(function ($attachment) {
                 $attachment->field(function ($field) {
-                    $system = MapDenormalize::find($this->notification->text['solarSystemID']);
+                    $system = MapDenormalize::firstOrNew(
+                        ['itemID' => $this->notification->text['solarSystemID']],
+                        ['itemName' => trans('web::seat.unknown'), 'security' => 0]
+                    );
 
                     $field->title('System')
                         ->content(
@@ -74,7 +96,10 @@ class OwnershipTransferred extends AbstractSlackNotification
                 });
 
                 $attachment->field(function ($field) {
-                    $type = InvType::find($this->notification->text['structureTypeID']);
+                    $type = InvType::firstOrNew(
+                        ['typeID' => $this->notification->text['structureTypeID']],
+                        ['typeName' => trans('web::seat.unknown')]
+                    );
 
                     $field->title('Structure')
                         ->content(sprintf('%s | %s', $type->typeName, $this->notification->text['structureName']));
@@ -84,7 +109,7 @@ class OwnershipTransferred extends AbstractSlackNotification
                 $attachment->field(function ($field) {
                     $old = UniverseName::firstOrNew(
                         ['entity_id' => $this->notification->text['oldOwnerCorpID']],
-                        ['name' => trans('web::seat.unknown')]
+                        ['category' => 'corporation', 'name' => trans('web::seat.unknown')]
                     );
 
                     $field->title('Old Corporation')
@@ -94,7 +119,7 @@ class OwnershipTransferred extends AbstractSlackNotification
                 $attachment->field(function ($field) {
                     $new = UniverseName::firstOrNew(
                         ['entity_id' => $this->notification->text['newOwnerCorpID']],
-                        ['name' => trans('web::seat.unknown')]
+                        ['category' => 'corporation', 'name' => trans('web::seat.unknown')]
                     );
 
                     $field->title('New Corporation')

--- a/src/Notifications/Structures/Slack/SkyhookDeployed.php
+++ b/src/Notifications/Structures/Slack/SkyhookDeployed.php
@@ -83,8 +83,8 @@ class SkyhookDeployed extends AbstractSlackNotification
             })
             ->attachment(function ($attachment) {
                 $attachment->field(function ($field) {
-                    $field->title('Remaining Time')
-                        ->content($this->notification->text['timeLeft']);
+                    $field->title('Online At (UTC)')
+                        ->content($this->eveDurationToDateTimeString($this->notification->text['timeLeft'], $this->notification->timestamp));
                 });
 
                 $attachment->color('warning');

--- a/src/Notifications/Structures/Slack/SkyhookDeployed.php
+++ b/src/Notifications/Structures/Slack/SkyhookDeployed.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Notifications\Notifications\Structures\Slack;
+
+use Illuminate\Notifications\Messages\SlackMessage;
+use Seat\Eveapi\Models\Character\CharacterNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
+use Seat\Notifications\Notifications\Structures\Traits\SkyhookNotificationTools;
+use Seat\Notifications\Traits\NotificationTools;
+
+class SkyhookDeployed extends AbstractSlackNotification
+{
+    use NotificationTools;
+    use SkyhookNotificationTools;
+
+    private $notification;
+
+    public function __construct(CharacterNotification $notification)
+    {
+        $this->notification = $notification;
+    }
+
+    public function toSlack($notifiable)
+    {
+        $system = $this->getSkyhookSystem();
+        $planet = $this->getSkyhookPlanet();
+        $type = $this->getSkyhookType();
+
+        return (new SlackMessage)
+            ->content('A new Skyhook is deploying!')
+            ->from('SeAT Structure Monitor')
+            ->attachment(function ($attachment) use ($system, $planet) {
+                $attachment->field(function ($field) use ($system) {
+                    $field->title('System')
+                        ->content($this->zKillBoardToSlackLink(
+                            'system',
+                            $system->itemID,
+                            sprintf('%s (%s)', $system->itemName, number_format($system->security, 2))
+                        ));
+                });
+
+                $attachment->field(function ($field) use ($planet) {
+                    $field->title('Planet')
+                        ->content($planet->itemName);
+                });
+
+                if (array_key_exists('ownerCorpLinkData', $this->notification->text) && array_key_exists('ownerCorpName', $this->notification->text)) {
+                    $attachment->field(function ($field) {
+                        $field->title('Owner')
+                            ->content($this->zKillBoardToSlackLink(
+                                'corporation',
+                                $this->notification->text['ownerCorpLinkData'][2],
+                                $this->notification->text['ownerCorpName']
+                            ));
+                    });
+                }
+            })
+            ->attachment(function ($attachment) use ($type) {
+                $attachment->field(function ($field) use ($type) {
+                    $field->title($this->getSkyhookName())
+                        ->content($this->zKillBoardToSlackLink('ship', $type->typeID, $type->typeName));
+                });
+            })
+            ->attachment(function ($attachment) {
+                $attachment->field(function ($field) {
+                    $field->title('Remaining Time')
+                        ->content($this->notification->text['timeLeft']);
+                });
+
+                $attachment->color('warning');
+            });
+    }
+}

--- a/src/Notifications/Structures/Slack/SkyhookDestroyed.php
+++ b/src/Notifications/Structures/Slack/SkyhookDestroyed.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Notifications\Notifications\Structures\Slack;
+
+use Illuminate\Notifications\Messages\SlackMessage;
+use Seat\Eveapi\Models\Character\CharacterNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
+use Seat\Notifications\Notifications\Structures\Traits\SkyhookNotificationTools;
+use Seat\Notifications\Traits\NotificationTools;
+
+class SkyhookDestroyed extends AbstractSlackNotification
+{
+    use NotificationTools;
+    use SkyhookNotificationTools;
+
+    private $notification;
+
+    public function __construct(CharacterNotification $notification)
+    {
+        $this->notification = $notification;
+    }
+
+    public function toSlack($notifiable)
+    {
+        $system = $this->getSkyhookSystem();
+        $planet = $this->getSkyhookPlanet();
+        $type = $this->getSkyhookType();
+
+        return (new SlackMessage)
+            ->content('A Skyhook has been destroyed!')
+            ->from('SeAT Structure Monitor')
+            ->attachment(function ($attachment) use ($system, $planet) {
+                $attachment->field(function ($field) use ($system) {
+                    $field->title('System')
+                        ->content($this->zKillBoardToSlackLink(
+                            'system',
+                            $system->itemID,
+                            sprintf('%s (%s)', $system->itemName, number_format($system->security, 2))
+                        ));
+                });
+
+                $attachment->field(function ($field) use ($planet) {
+                    $field->title('Planet')
+                        ->content($planet->itemName);
+                });
+
+                if (array_key_exists('ownerCorpLinkData', $this->notification->text) && array_key_exists('ownerCorpName', $this->notification->text)) {
+                    $attachment->field(function ($field) {
+                        $field->title('Owner')
+                            ->content($this->zKillBoardToSlackLink(
+                                'corporation',
+                                $this->notification->text['ownerCorpLinkData'][2],
+                                $this->notification->text['ownerCorpName']
+                            ));
+                    });
+                }
+            })
+            ->attachment(function ($attachment) use ($type) {
+                $attachment->field(function ($field) use ($type) {
+                    $field->title($this->getSkyhookName())
+                        ->content($this->zKillBoardToSlackLink('ship', $type->typeID, $type->typeName));
+                });
+
+                $attachment->color('danger');
+            });
+    }
+}

--- a/src/Notifications/Structures/Slack/SkyhookLostShields.php
+++ b/src/Notifications/Structures/Slack/SkyhookLostShields.php
@@ -23,12 +23,16 @@
 namespace Seat\Notifications\Notifications\Structures\Slack;
 
 use Illuminate\Notifications\Messages\SlackMessage;
+use Illuminate\Support\Collection;
 use Seat\Eveapi\Models\Character\CharacterNotification;
+use Seat\Eveapi\Models\Universe\UniverseName;
+use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
+use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Notifications\Structures\Traits\SkyhookNotificationTools;
 use Seat\Notifications\Traits\NotificationTools;
 
-class SkyhookLostShields extends AbstractSlackNotification
+class SkyhookLostShields extends AbstractSlackNotification implements ExposesRequiredUniverseIds
 {
     use NotificationTools;
     use SkyhookNotificationTools;
@@ -40,8 +44,40 @@ class SkyhookLostShields extends AbstractSlackNotification
         $this->notification = $notification;
     }
 
+    public function middleware(): array
+    {
+        return array_merge(
+            parent::middleware(),
+            [new LoadRequiredUniverseIds]
+        );
+    }
+
+    public function getRequiredUniverseIds(): Collection
+    {
+        return collect([
+            $this->notification->text['charID'] ?? null,
+            $this->notification->text['corpLinkData'][2] ?? null,
+            $this->notification->text['allianceID'] ?? null,
+        ])->filter()->unique()->values();
+    }
+
     public function toSlack($notifiable)
     {
+        $character_id = $this->notification->text['charID'] ?? null;
+        $corporation_id = $this->notification->text['corpLinkData'][2] ?? null;
+        $alliance_id = $this->notification->text['allianceID'] ?? null;
+        $attacker = is_null($character_id) ? null : UniverseName::firstOrNew(
+            ['entity_id' => $character_id],
+            ['category' => 'character', 'name' => trans('web::seat.unknown')]
+        );
+        $corporation = is_null($corporation_id) ? null : UniverseName::firstOrNew(
+            ['entity_id' => $corporation_id],
+            ['category' => 'corporation', 'name' => trans('web::seat.unknown')]
+        );
+        $alliance = is_null($alliance_id) ? null : UniverseName::firstOrNew(
+            ['entity_id' => $alliance_id],
+            ['category' => 'alliance', 'name' => trans('web::seat.unknown')]
+        );
         $system = $this->getSkyhookSystem();
         $planet = $this->getSkyhookPlanet();
         $type = $this->getSkyhookType();
@@ -49,7 +85,30 @@ class SkyhookLostShields extends AbstractSlackNotification
         return (new SlackMessage)
             ->content('A Skyhook lost Shields!')
             ->from('SeAT Structure Monitor')
-            ->attachment(function ($attachment) use ($system, $planet) {
+            ->attachment(function ($attachment) use ($attacker, $character_id, $corporation, $corporation_id, $alliance, $alliance_id, $system, $planet) {
+                if (! is_null($attacker) && ! is_null($character_id)) {
+                    $attachment->field(function ($field) use ($attacker, $character_id) {
+                        $field->title('Character')
+                            ->content($this->zKillBoardToSlackLink('character', $character_id, $attacker->name));
+                    });
+                }
+
+                if (! is_null($corporation) && ! is_null($corporation_id)) {
+                    $corporation_name = $this->notification->text['corpName'] ?? $corporation->name;
+                    $attachment->field(function ($field) use ($corporation_id, $corporation_name) {
+                        $field->title('Corporation')
+                            ->content($this->zKillBoardToSlackLink('corporation', $corporation_id, $corporation_name));
+                    });
+                }
+
+                if (! is_null($alliance) && ! is_null($alliance_id)) {
+                    $alliance_name = $this->notification->text['allianceName'] ?? $alliance->name;
+                    $attachment->field(function ($field) use ($alliance_id, $alliance_name) {
+                        $field->title('Alliance')
+                            ->content($this->zKillBoardToSlackLink('alliance', $alliance_id, $alliance_name));
+                    });
+                }
+
                 $attachment->field(function ($field) use ($system) {
                     $field->title('System')
                         ->content($this->zKillBoardToSlackLink(
@@ -69,6 +128,23 @@ class SkyhookLostShields extends AbstractSlackNotification
                     $field->title($this->getSkyhookName())
                         ->content($this->zKillBoardToSlackLink('ship', $type->typeID, $type->typeName));
                 });
+
+                $attachment->color('warning');
+            })
+            ->attachment(function ($attachment) {
+                if (array_key_exists('timeLeft', $this->notification->text)) {
+                    $attachment->field(function ($field) {
+                        $field->title('Reinforcement Timer')
+                            ->content($this->eveDurationToDateTimeString($this->notification->text['timeLeft'], $this->notification->timestamp));
+                    });
+                }
+
+                if (array_key_exists('vulnerableTime', $this->notification->text)) {
+                    $attachment->field(function ($field) {
+                        $field->title('Vulnerability Window')
+                            ->content($this->eveDurationToString($this->notification->text['vulnerableTime']));
+                    });
+                }
 
                 $attachment->color('warning');
             });

--- a/src/Notifications/Structures/Slack/SkyhookLostShields.php
+++ b/src/Notifications/Structures/Slack/SkyhookLostShields.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Notifications\Notifications\Structures\Slack;
+
+use Illuminate\Notifications\Messages\SlackMessage;
+use Seat\Eveapi\Models\Character\CharacterNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
+use Seat\Notifications\Notifications\Structures\Traits\SkyhookNotificationTools;
+use Seat\Notifications\Traits\NotificationTools;
+
+class SkyhookLostShields extends AbstractSlackNotification
+{
+    use NotificationTools;
+    use SkyhookNotificationTools;
+
+    private $notification;
+
+    public function __construct(CharacterNotification $notification)
+    {
+        $this->notification = $notification;
+    }
+
+    public function toSlack($notifiable)
+    {
+        $system = $this->getSkyhookSystem();
+        $planet = $this->getSkyhookPlanet();
+        $type = $this->getSkyhookType();
+
+        return (new SlackMessage)
+            ->content('A Skyhook lost Shields!')
+            ->from('SeAT Structure Monitor')
+            ->attachment(function ($attachment) use ($system, $planet) {
+                $attachment->field(function ($field) use ($system) {
+                    $field->title('System')
+                        ->content($this->zKillBoardToSlackLink(
+                            'system',
+                            $system->itemID,
+                            sprintf('%s (%s)', $system->itemName, number_format($system->security, 2))
+                        ));
+                });
+
+                $attachment->field(function ($field) use ($planet) {
+                    $field->title('Planet')
+                        ->content($planet->itemName);
+                });
+            })
+            ->attachment(function ($attachment) use ($type) {
+                $attachment->field(function ($field) use ($type) {
+                    $field->title($this->getSkyhookName())
+                        ->content($this->zKillBoardToSlackLink('ship', $type->typeID, $type->typeName));
+                });
+
+                $attachment->color('warning');
+            });
+    }
+}

--- a/src/Notifications/Structures/Slack/SkyhookOnline.php
+++ b/src/Notifications/Structures/Slack/SkyhookOnline.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Notifications\Notifications\Structures\Slack;
+
+use Illuminate\Notifications\Messages\SlackMessage;
+use Seat\Eveapi\Models\Character\CharacterNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
+use Seat\Notifications\Notifications\Structures\Traits\SkyhookNotificationTools;
+use Seat\Notifications\Traits\NotificationTools;
+
+class SkyhookOnline extends AbstractSlackNotification
+{
+    use NotificationTools;
+    use SkyhookNotificationTools;
+
+    private $notification;
+
+    public function __construct(CharacterNotification $notification)
+    {
+        $this->notification = $notification;
+    }
+
+    public function toSlack($notifiable)
+    {
+        $system = $this->getSkyhookSystem();
+        $planet = $this->getSkyhookPlanet();
+        $type = $this->getSkyhookType();
+
+        return (new SlackMessage)
+            ->content('A Skyhook went online!')
+            ->from('SeAT Structure Monitor')
+            ->attachment(function ($attachment) use ($system, $planet) {
+                $attachment->field(function ($field) use ($system) {
+                    $field->title('System')
+                        ->content($this->zKillBoardToSlackLink(
+                            'system',
+                            $system->itemID,
+                            sprintf('%s (%s)', $system->itemName, number_format($system->security, 2))
+                        ));
+                });
+
+                $attachment->field(function ($field) use ($planet) {
+                    $field->title('Planet')
+                        ->content($planet->itemName);
+                });
+            })
+            ->attachment(function ($attachment) use ($type) {
+                $attachment->field(function ($field) use ($type) {
+                    $field->title($this->getSkyhookName())
+                        ->content($this->zKillBoardToSlackLink('ship', $type->typeID, $type->typeName));
+                });
+            });
+    }
+}

--- a/src/Notifications/Structures/Slack/SkyhookUnderAttack.php
+++ b/src/Notifications/Structures/Slack/SkyhookUnderAttack.php
@@ -23,12 +23,16 @@
 namespace Seat\Notifications\Notifications\Structures\Slack;
 
 use Illuminate\Notifications\Messages\SlackMessage;
+use Illuminate\Support\Collection;
 use Seat\Eveapi\Models\Character\CharacterNotification;
+use Seat\Eveapi\Models\Universe\UniverseName;
+use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
+use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Notifications\Structures\Traits\SkyhookNotificationTools;
 use Seat\Notifications\Traits\NotificationTools;
 
-class SkyhookUnderAttack extends AbstractSlackNotification
+class SkyhookUnderAttack extends AbstractSlackNotification implements ExposesRequiredUniverseIds
 {
     use NotificationTools;
     use SkyhookNotificationTools;
@@ -40,8 +44,27 @@ class SkyhookUnderAttack extends AbstractSlackNotification
         $this->notification = $notification;
     }
 
+    public function middleware(): array
+    {
+        return array_merge(
+            parent::middleware(),
+            [new LoadRequiredUniverseIds]
+        );
+    }
+
+    public function getRequiredUniverseIds(): Collection
+    {
+        return collect([
+            $this->notification->text['charID'] ?? null,
+        ])->filter()->unique()->values();
+    }
+
     public function toSlack($notifiable)
     {
+        $attacker = UniverseName::firstOrNew(
+            ['entity_id' => $this->notification->text['charID']],
+            ['category' => 'character', 'name' => trans('web::seat.unknown')]
+        );
         $system = $this->getSkyhookSystem();
         $planet = $this->getSkyhookPlanet();
         $type = $this->getSkyhookType();
@@ -49,9 +72,18 @@ class SkyhookUnderAttack extends AbstractSlackNotification
         return (new SlackMessage)
             ->content('A Skyhook is under attack!')
             ->from('SeAT Structure Monitor')
-            ->attachment(function ($attachment) use ($system, $planet, $type) {
+            ->attachment(function ($attachment) use ($attacker, $system, $planet, $type) {
+                $attachment->field(function ($field) use ($attacker) {
+                    $field->title('Character')
+                        ->content($this->zKillBoardToSlackLink(
+                            'character',
+                            $this->notification->text['charID'],
+                            $attacker->name
+                        ));
+                });
+
                 $attachment->field(function ($field) {
-                    $field->title('Attacker')
+                    $field->title('Corporation')
                         ->content($this->zKillBoardToSlackLink(
                             'corporation',
                             $this->notification->text['corpLinkData'][2],

--- a/src/Notifications/Structures/Slack/SkyhookUnderAttack.php
+++ b/src/Notifications/Structures/Slack/SkyhookUnderAttack.php
@@ -1,0 +1,129 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Notifications\Notifications\Structures\Slack;
+
+use Illuminate\Notifications\Messages\SlackMessage;
+use Seat\Eveapi\Models\Character\CharacterNotification;
+use Seat\Notifications\Notifications\AbstractSlackNotification;
+use Seat\Notifications\Notifications\Structures\Traits\SkyhookNotificationTools;
+use Seat\Notifications\Traits\NotificationTools;
+
+class SkyhookUnderAttack extends AbstractSlackNotification
+{
+    use NotificationTools;
+    use SkyhookNotificationTools;
+
+    private $notification;
+
+    public function __construct(CharacterNotification $notification)
+    {
+        $this->notification = $notification;
+    }
+
+    public function toSlack($notifiable)
+    {
+        $system = $this->getSkyhookSystem();
+        $planet = $this->getSkyhookPlanet();
+        $type = $this->getSkyhookType();
+
+        return (new SlackMessage)
+            ->content('A Skyhook is under attack!')
+            ->from('SeAT Structure Monitor')
+            ->attachment(function ($attachment) use ($system, $planet, $type) {
+                $attachment->field(function ($field) {
+                    $field->title('Attacker')
+                        ->content($this->zKillBoardToSlackLink(
+                            'corporation',
+                            $this->notification->text['corpLinkData'][2],
+                            $this->notification->text['corpName']
+                        ));
+                });
+
+                if (array_key_exists('allianceID', $this->notification->text) && ! is_null($this->notification->text['allianceID'])) {
+                    $attachment->field(function ($field) {
+                        $field->title('Alliance')
+                            ->content($this->zKillBoardToSlackLink(
+                                'alliance',
+                                $this->notification->text['allianceID'],
+                                $this->notification->text['allianceName']
+                            ));
+                    });
+                }
+
+                $attachment->field(function ($field) use ($system) {
+                    $field->title('System')
+                        ->content($this->zKillBoardToSlackLink(
+                            'system',
+                            $system->itemID,
+                            sprintf('%s (%s)', $system->itemName, number_format($system->security, 2))
+                        ));
+                });
+
+                $attachment->field(function ($field) use ($planet) {
+                    $field->title('Planet')
+                        ->content($planet->itemName);
+                });
+
+                $attachment->field(function ($field) use ($type) {
+                    $field->title($this->getSkyhookName())
+                        ->content($this->zKillBoardToSlackLink('ship', $type->typeID, $type->typeName));
+                });
+            })
+            ->attachment(function ($attachment) {
+                $attachment->field(function ($field) {
+                    $field->title('Shield')
+                        ->content(number_format($this->notification->text['shieldPercentage'], 2));
+                })->color('good');
+
+                if ($this->notification->text['shieldPercentage'] < 70)
+                    $attachment->color('warning');
+
+                if ($this->notification->text['shieldPercentage'] < 40)
+                    $attachment->color('danger');
+            })
+            ->attachment(function ($attachment) {
+                $attachment->field(function ($field) {
+                    $field->title('Armor')
+                        ->content(number_format($this->notification->text['armorPercentage'], 2));
+                })->color('good');
+
+                if ($this->notification->text['armorPercentage'] < 70)
+                    $attachment->color('warning');
+
+                if ($this->notification->text['armorPercentage'] < 40)
+                    $attachment->color('danger');
+            })
+            ->attachment(function ($attachment) {
+                $attachment->field(function ($field) {
+                    $field->title('Hull')
+                        ->content(number_format($this->notification->text['hullPercentage'], 2));
+                })->color('good');
+
+                if ($this->notification->text['hullPercentage'] < 70)
+                    $attachment->color('warning');
+
+                if ($this->notification->text['hullPercentage'] < 40)
+                    $attachment->color('danger');
+            });
+    }
+}

--- a/src/Notifications/Structures/Slack/StructureAnchoring.php
+++ b/src/Notifications/Structures/Slack/StructureAnchoring.php
@@ -98,13 +98,13 @@ class StructureAnchoring extends AbstractSlackNotification
             })
             ->attachment(function ($attachment) {
                 $attachment->field(function ($field) {
-                    $field->title('Remaining Time')
-                        ->content($this->notification->text['timeLeft']);
+                    $field->title('Anchors At (UTC)')
+                        ->content($this->eveDurationToDateTimeString($this->notification->text['timeLeft'], $this->notification->timestamp));
                 });
 
                 $attachment->field(function ($field) {
-                    $field->title('Vulnerability Time')
-                        ->content($this->notification->text['vulnerableTime']);
+                    $field->title('Vulnerability Window')
+                        ->content($this->eveDurationToString($this->notification->text['vulnerableTime']));
                 });
             })
             ->warning();

--- a/src/Notifications/Structures/Slack/StructureLostArmor.php
+++ b/src/Notifications/Structures/Slack/StructureLostArmor.php
@@ -23,9 +23,14 @@
 namespace Seat\Notifications\Notifications\Structures\Slack;
 
 use Illuminate\Notifications\Messages\SlackMessage;
+use Illuminate\Support\Collection;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
+use Seat\Eveapi\Models\Universe\UniverseName;
+use Seat\Eveapi\Models\Universe\UniverseStructure;
+use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
+use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 
@@ -34,7 +39,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Structures\Slack
  */
-class StructureLostArmor extends AbstractSlackNotification
+class StructureLostArmor extends AbstractSlackNotification implements ExposesRequiredUniverseIds
 {
     use NotificationTools;
 
@@ -53,22 +58,83 @@ class StructureLostArmor extends AbstractSlackNotification
         $this->notification = $notification;
     }
 
+    public function middleware(): array
+    {
+        return array_merge(
+            parent::middleware(),
+            [new LoadRequiredUniverseIds]
+        );
+    }
+
+    public function getRequiredUniverseIds(): Collection
+    {
+        return collect([
+            $this->notification->text['charID'] ?? null,
+            $this->notification->text['corpLinkData'][2] ?? null,
+            $this->notification->text['allianceID'] ?? null,
+        ])->filter()->unique()->values();
+    }
+
     /**
      * @param  $notifiable
      * @return \Illuminate\Notifications\Messages\SlackMessage
      */
     public function toSlack($notifiable)
     {
+        $character_id = $this->notification->text['charID'] ?? null;
+        $corporation_id = $this->notification->text['corpLinkData'][2] ?? null;
+        $alliance_id = $this->notification->text['allianceID'] ?? null;
+        $attacker = is_null($character_id) ? null : UniverseName::firstOrNew(
+            ['entity_id' => $character_id],
+            ['category' => 'character', 'name' => trans('web::seat.unknown')]
+        );
+        $corporation = is_null($corporation_id) ? null : UniverseName::firstOrNew(
+            ['entity_id' => $corporation_id],
+            ['category' => 'corporation', 'name' => trans('web::seat.unknown')]
+        );
+        $alliance = is_null($alliance_id) ? null : UniverseName::firstOrNew(
+            ['entity_id' => $alliance_id],
+            ['category' => 'alliance', 'name' => trans('web::seat.unknown')]
+        );
+        $system = MapDenormalize::firstOrNew(
+            ['itemID' => $this->notification->text['solarsystemID']],
+            ['itemName' => trans('web::seat.unknown'), 'security' => 0]
+        );
+        $type = InvType::firstOrNew(
+            ['typeID' => $this->notification->text['structureTypeID']],
+            ['typeName' => trans('web::seat.unknown')]
+        );
+        $structure = UniverseStructure::find($this->notification->text['structureID'] ?? 0);
+        $structure_name = ! is_null($structure) && ! empty($structure->name) ? $structure->name : 'Structure';
+
         return (new SlackMessage)
             ->content('A Structure lost Armor!')
             ->from('SeAT Structure Monitor')
-            ->attachment(function ($attachment) {
-                $attachment->field(function ($field) {
-                    $system = MapDenormalize::firstOrNew(
-                        ['itemID' => $this->notification->text['solarsystemID']],
-                        ['itemName' => trans('web::seat.unknown')]
-                    );
+            ->attachment(function ($attachment) use ($attacker, $character_id, $corporation, $corporation_id, $alliance, $alliance_id, $system, $type, $structure_name) {
+                if (! is_null($attacker) && ! is_null($character_id)) {
+                    $attachment->field(function ($field) use ($attacker, $character_id) {
+                        $field->title('Character')
+                            ->content($this->zKillBoardToSlackLink('character', $character_id, $attacker->name));
+                    });
+                }
 
+                if (! is_null($corporation) && ! is_null($corporation_id)) {
+                    $corporation_name = $this->notification->text['corpName'] ?? $corporation->name;
+                    $attachment->field(function ($field) use ($corporation_id, $corporation_name) {
+                        $field->title('Corporation')
+                            ->content($this->zKillBoardToSlackLink('corporation', $corporation_id, $corporation_name));
+                    });
+                }
+
+                if (! is_null($alliance) && ! is_null($alliance_id)) {
+                    $alliance_name = $this->notification->text['allianceName'] ?? $alliance->name;
+                    $attachment->field(function ($field) use ($alliance_id, $alliance_name) {
+                        $field->title('Alliance')
+                            ->content($this->zKillBoardToSlackLink('alliance', $alliance_id, $alliance_name));
+                    });
+                }
+
+                $attachment->field(function ($field) use ($system) {
                     $field->title('System')
                         ->content($this->zKillBoardToSlackLink(
                             'system',
@@ -76,15 +142,24 @@ class StructureLostArmor extends AbstractSlackNotification
                             sprintf('%s (%s)', $system->itemName, number_format($system->security, 2))));
                 });
 
-                $attachment->field(function ($field) {
-                    $type = InvType::firstOrNew(
-                        ['typeID' => $this->notification->text['structureTypeID']],
-                        ['typeName' => trans('web::seat.unknown')]
-                    );
-
-                    $field->title('Structure')
+                $attachment->field(function ($field) use ($type, $structure_name) {
+                    $field->title($structure_name)
                         ->content($this->zKillBoardToSlackLink('ship', $type->typeID, $type->typeName));
                 });
+
+                if (array_key_exists('timeLeft', $this->notification->text)) {
+                    $attachment->field(function ($field) {
+                        $field->title('Reinforcement Timer')
+                            ->content($this->eveDurationToDateTimeString($this->notification->text['timeLeft'], $this->notification->timestamp));
+                    });
+                }
+
+                if (array_key_exists('vulnerableTime', $this->notification->text)) {
+                    $attachment->field(function ($field) {
+                        $field->title('Vulnerability Window')
+                            ->content($this->eveDurationToString($this->notification->text['vulnerableTime']));
+                    });
+                }
             })
             ->warning();
     }

--- a/src/Notifications/Structures/Slack/StructureLostShields.php
+++ b/src/Notifications/Structures/Slack/StructureLostShields.php
@@ -23,9 +23,14 @@
 namespace Seat\Notifications\Notifications\Structures\Slack;
 
 use Illuminate\Notifications\Messages\SlackMessage;
+use Illuminate\Support\Collection;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
+use Seat\Eveapi\Models\Universe\UniverseName;
+use Seat\Eveapi\Models\Universe\UniverseStructure;
+use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
+use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 
@@ -34,7 +39,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Structures\Slack
  */
-class StructureLostShields extends AbstractSlackNotification
+class StructureLostShields extends AbstractSlackNotification implements ExposesRequiredUniverseIds
 {
     use NotificationTools;
 
@@ -53,22 +58,83 @@ class StructureLostShields extends AbstractSlackNotification
         $this->notification = $notification;
     }
 
+    public function middleware(): array
+    {
+        return array_merge(
+            parent::middleware(),
+            [new LoadRequiredUniverseIds]
+        );
+    }
+
+    public function getRequiredUniverseIds(): Collection
+    {
+        return collect([
+            $this->notification->text['charID'] ?? null,
+            $this->notification->text['corpLinkData'][2] ?? null,
+            $this->notification->text['allianceID'] ?? null,
+        ])->filter()->unique()->values();
+    }
+
     /**
      * @param  $notifiable
      * @return \Illuminate\Notifications\Messages\SlackMessage
      */
     public function toSlack($notifiable)
     {
+        $character_id = $this->notification->text['charID'] ?? null;
+        $corporation_id = $this->notification->text['corpLinkData'][2] ?? null;
+        $alliance_id = $this->notification->text['allianceID'] ?? null;
+        $attacker = is_null($character_id) ? null : UniverseName::firstOrNew(
+            ['entity_id' => $character_id],
+            ['category' => 'character', 'name' => trans('web::seat.unknown')]
+        );
+        $corporation = is_null($corporation_id) ? null : UniverseName::firstOrNew(
+            ['entity_id' => $corporation_id],
+            ['category' => 'corporation', 'name' => trans('web::seat.unknown')]
+        );
+        $alliance = is_null($alliance_id) ? null : UniverseName::firstOrNew(
+            ['entity_id' => $alliance_id],
+            ['category' => 'alliance', 'name' => trans('web::seat.unknown')]
+        );
+        $system = MapDenormalize::firstOrNew(
+            ['itemID' => $this->notification->text['solarsystemID']],
+            ['itemName' => trans('web::seat.unknown'), 'security' => 0]
+        );
+        $type = InvType::firstOrNew(
+            ['typeID' => $this->notification->text['structureTypeID']],
+            ['typeName' => trans('web::seat.unknown')]
+        );
+        $structure = UniverseStructure::find($this->notification->text['structureID'] ?? 0);
+        $structure_name = ! is_null($structure) && ! empty($structure->name) ? $structure->name : 'Structure';
+
         return (new SlackMessage)
             ->content('A Structure lost Shield!')
             ->from('SeAT Structure Monitor')
-            ->attachment(function ($attachment) {
-                $attachment->field(function ($field) {
-                    $system = MapDenormalize::firstOrNew(
-                        ['itemID' => $this->notification->text['solarsystemID']],
-                        ['itemName' => trans('web::seat.unknown')]
-                    );
+            ->attachment(function ($attachment) use ($attacker, $character_id, $corporation, $corporation_id, $alliance, $alliance_id, $system, $type, $structure_name) {
+                if (! is_null($attacker) && ! is_null($character_id)) {
+                    $attachment->field(function ($field) use ($attacker, $character_id) {
+                        $field->title('Character')
+                            ->content($this->zKillBoardToSlackLink('character', $character_id, $attacker->name));
+                    });
+                }
 
+                if (! is_null($corporation) && ! is_null($corporation_id)) {
+                    $corporation_name = $this->notification->text['corpName'] ?? $corporation->name;
+                    $attachment->field(function ($field) use ($corporation_id, $corporation_name) {
+                        $field->title('Corporation')
+                            ->content($this->zKillBoardToSlackLink('corporation', $corporation_id, $corporation_name));
+                    });
+                }
+
+                if (! is_null($alliance) && ! is_null($alliance_id)) {
+                    $alliance_name = $this->notification->text['allianceName'] ?? $alliance->name;
+                    $attachment->field(function ($field) use ($alliance_id, $alliance_name) {
+                        $field->title('Alliance')
+                            ->content($this->zKillBoardToSlackLink('alliance', $alliance_id, $alliance_name));
+                    });
+                }
+
+                $attachment->field(function ($field) use ($system) {
                     $field->title('System')
                         ->content($this->zKillBoardToSlackLink(
                             'system',
@@ -76,15 +142,24 @@ class StructureLostShields extends AbstractSlackNotification
                             sprintf('%s (%s)', $system->itemName, number_format($system->security, 2))));
                 });
 
-                $attachment->field(function ($field) {
-                    $type = InvType::firstOrNew(
-                        ['typeID' => $this->notification->text['structureTypeID']],
-                        ['typeName' => trans('web::seat.unknown')]
-                    );
-
-                    $field->title('Structure')
+                $attachment->field(function ($field) use ($type, $structure_name) {
+                    $field->title($structure_name)
                         ->content($this->zKillBoardToSlackLink('ship', $type->typeID, $type->typeName));
                 });
+
+                if (array_key_exists('timeLeft', $this->notification->text)) {
+                    $attachment->field(function ($field) {
+                        $field->title('Reinforcement Timer')
+                            ->content($this->eveDurationToDateTimeString($this->notification->text['timeLeft'], $this->notification->timestamp));
+                    });
+                }
+
+                if (array_key_exists('vulnerableTime', $this->notification->text)) {
+                    $attachment->field(function ($field) {
+                        $field->title('Vulnerability Window')
+                            ->content($this->eveDurationToString($this->notification->text['vulnerableTime']));
+                    });
+                }
             })
             ->warning();
     }

--- a/src/Notifications/Structures/Slack/StructureUnanchoring.php
+++ b/src/Notifications/Structures/Slack/StructureUnanchoring.php
@@ -98,8 +98,8 @@ class StructureUnanchoring extends AbstractSlackNotification
             })
             ->attachment(function ($attachment) {
                 $attachment->field(function ($field) {
-                    $field->title('Remaining Time')
-                        ->content($this->notification->text['timeLeft']);
+                    $field->title('Unanchors At (UTC)')
+                        ->content($this->eveDurationToDateTimeString($this->notification->text['timeLeft'], $this->notification->timestamp));
                 });
             })
             ->warning();

--- a/src/Notifications/Structures/Slack/StructureUnderAttack.php
+++ b/src/Notifications/Structures/Slack/StructureUnderAttack.php
@@ -23,10 +23,14 @@
 namespace Seat\Notifications\Notifications\Structures\Slack;
 
 use Illuminate\Notifications\Messages\SlackMessage;
+use Illuminate\Support\Collection;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
+use Seat\Eveapi\Models\Universe\UniverseName;
 use Seat\Eveapi\Models\Universe\UniverseStructure;
+use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
+use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 
@@ -35,7 +39,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Structures
  */
-class StructureUnderAttack extends AbstractSlackNotification
+class StructureUnderAttack extends AbstractSlackNotification implements ExposesRequiredUniverseIds
 {
     use NotificationTools;
 
@@ -54,18 +58,47 @@ class StructureUnderAttack extends AbstractSlackNotification
         $this->notification = $notification;
     }
 
+    public function middleware(): array
+    {
+        return array_merge(
+            parent::middleware(),
+            [new LoadRequiredUniverseIds]
+        );
+    }
+
+    public function getRequiredUniverseIds(): Collection
+    {
+        return collect([
+            $this->notification->text['charID'] ?? null,
+        ])->filter()->unique()->values();
+    }
+
     /**
      * @param  $notifiable
      * @return \Illuminate\Notifications\Messages\SlackMessage
      */
     public function toSlack($notifiable)
     {
+        $attacker = UniverseName::firstOrNew(
+            ['entity_id' => $this->notification->text['charID']],
+            ['category' => 'character', 'name' => trans('web::seat.unknown')]
+        );
+
         return (new SlackMessage)
             ->content('A structure is under attack!')
             ->from('SeAT Structure Monitor')
-            ->attachment(function ($attachment) {
-                $attachment->field(function ($field) {
-                    $field->title('Attacker')
+            ->attachment(function ($attachment) use ($attacker) {
+                $attachment->field(function ($field) use ($attacker) {
+                    $field->title('Character')
+                        ->content(
+                            $this->zKillBoardToSlackLink(
+                                'character',
+                                $this->notification->text['charID'],
+                                $attacker->name
+                            ));
+                    })
+                    ->field(function ($field) {
+                        $field->title('Corporation')
                         ->content(
                             $this->zKillBoardToSlackLink(
                                 'corporation',

--- a/src/Notifications/Structures/Traits/SkyhookNotificationTools.php
+++ b/src/Notifications/Structures/Traits/SkyhookNotificationTools.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Notifications\Notifications\Structures\Traits;
+
+use Seat\Eveapi\Models\Sde\InvType;
+use Seat\Eveapi\Models\Sde\MapDenormalize;
+use Seat\Eveapi\Models\Universe\UniverseStructure;
+
+trait SkyhookNotificationTools
+{
+    protected function getSkyhookId(): ?int
+    {
+        return $this->notification->text['itemID']
+            ?? ($this->notification->text['skyhookShowInfoData'][2] ?? null);
+    }
+
+    protected function getSkyhookType(): InvType
+    {
+        $type_id = $this->notification->text['typeID']
+            ?? ($this->notification->text['skyhookShowInfoData'][1] ?? null);
+
+        return InvType::firstOrNew(
+            ['typeID' => $type_id],
+            ['typeName' => trans('web::seat.unknown')]
+        );
+    }
+
+    protected function getSkyhookStructure(): ?UniverseStructure
+    {
+        $skyhook_id = $this->getSkyhookId();
+
+        return is_null($skyhook_id) ? null : UniverseStructure::find($skyhook_id);
+    }
+
+    protected function getSkyhookName(): string
+    {
+        $structure = $this->getSkyhookStructure();
+
+        if (! is_null($structure) && ! empty($structure->name))
+            return $structure->name;
+
+        return 'Skyhook';
+    }
+
+    protected function getSkyhookPlanet(): MapDenormalize
+    {
+        $planet_id = $this->notification->text['planetID']
+            ?? ($this->notification->text['planetShowInfoData'][2] ?? 0);
+
+        return MapDenormalize::firstOrNew(
+            ['itemID' => $planet_id],
+            ['itemName' => trans('web::seat.unknown')]
+        );
+    }
+
+    protected function getSkyhookSystem(): MapDenormalize
+    {
+        return MapDenormalize::firstOrNew(
+            ['itemID' => $this->notification->text['solarsystemID']],
+            ['itemName' => trans('web::seat.unknown'), 'security' => 0]
+        );
+    }
+}

--- a/src/Notifications/Wars/Discord/AllWarDeclaredMsg.php
+++ b/src/Notifications/Wars/Discord/AllWarDeclaredMsg.php
@@ -22,8 +22,11 @@
 
 namespace Seat\Notifications\Notifications\Wars\Discord;
 
+use Illuminate\Support\Collection;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Universe\UniverseName;
+use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
+use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
 use Seat\Notifications\Notifications\AbstractDiscordNotification;
 use Seat\Notifications\Services\Discord\Messages\DiscordEmbed;
 use Seat\Notifications\Services\Discord\Messages\DiscordEmbedField;
@@ -35,7 +38,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Wars\Discord
  */
-class AllWarDeclaredMsg extends AbstractDiscordNotification
+class AllWarDeclaredMsg extends AbstractDiscordNotification implements ExposesRequiredUniverseIds
 {
     use NotificationTools;
 
@@ -52,6 +55,22 @@ class AllWarDeclaredMsg extends AbstractDiscordNotification
     public function __construct(CharacterNotification $notification)
     {
         $this->notification = $notification;
+    }
+
+    public function middleware(): array
+    {
+        return array_merge(
+            parent::middleware(),
+            [new LoadRequiredUniverseIds]
+        );
+    }
+
+    public function getRequiredUniverseIds(): Collection
+    {
+        return collect([
+            $this->notification->text['declaredByID'] ?? null,
+            $this->notification->text['againstID'] ?? null,
+        ])->filter()->unique()->values();
     }
 
     /**

--- a/src/Notifications/Wars/Discord/AllWarDeclaredMsg.php
+++ b/src/Notifications/Wars/Discord/AllWarDeclaredMsg.php
@@ -65,7 +65,7 @@ class AllWarDeclaredMsg extends AbstractDiscordNotification
             ->embed(function (DiscordEmbed $embed) {
                 $embed->timestamp($this->notification->timestamp);
                 $embed->color($this->notification->text['hostileState'] ? 13632027 : 16098851);
-                $embed->author('SeAT War Observer', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT War Observer', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) {
                     $aggressor = UniverseName::firstOrNew(

--- a/src/Notifications/Wars/Discord/AllWarInvalidatedMsg.php
+++ b/src/Notifications/Wars/Discord/AllWarInvalidatedMsg.php
@@ -64,7 +64,7 @@ class AllWarInvalidatedMsg extends AbstractDiscordNotification
             ->content('A war has been invalidated! :boom:')
             ->embed(function (DiscordEmbed $embed) {
                 $embed->timestamp($this->notification->timestamp);
-                $embed->author('SeAT War Observer', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT War Observer', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) {
                     $aggressor = UniverseName::firstOrNew(

--- a/src/Notifications/Wars/Discord/AllWarInvalidatedMsg.php
+++ b/src/Notifications/Wars/Discord/AllWarInvalidatedMsg.php
@@ -22,8 +22,11 @@
 
 namespace Seat\Notifications\Notifications\Wars\Discord;
 
+use Illuminate\Support\Collection;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Universe\UniverseName;
+use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
+use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
 use Seat\Notifications\Notifications\AbstractDiscordNotification;
 use Seat\Notifications\Services\Discord\Messages\DiscordEmbed;
 use Seat\Notifications\Services\Discord\Messages\DiscordEmbedField;
@@ -35,7 +38,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Wars\Discord
  */
-class AllWarInvalidatedMsg extends AbstractDiscordNotification
+class AllWarInvalidatedMsg extends AbstractDiscordNotification implements ExposesRequiredUniverseIds
 {
     use NotificationTools;
 
@@ -52,6 +55,22 @@ class AllWarInvalidatedMsg extends AbstractDiscordNotification
     public function __construct(CharacterNotification $notification)
     {
         $this->notification = $notification;
+    }
+
+    public function middleware(): array
+    {
+        return array_merge(
+            parent::middleware(),
+            [new LoadRequiredUniverseIds]
+        );
+    }
+
+    public function getRequiredUniverseIds(): Collection
+    {
+        return collect([
+            $this->notification->text['declaredByID'] ?? null,
+            $this->notification->text['againstID'] ?? null,
+        ])->filter()->unique()->values();
     }
 
     /**

--- a/src/Notifications/Wars/Discord/AllyJoinedWarAggressorMsg.php
+++ b/src/Notifications/Wars/Discord/AllyJoinedWarAggressorMsg.php
@@ -64,7 +64,7 @@ class AllyJoinedWarAggressorMsg extends AbstractDiscordNotification
             ->content('A new member has been enroll in a war! :boom:')
             ->embed(function (DiscordEmbed $embed) {
                 $embed->timestamp($this->notification->timestamp);
-                $embed->author('SeAT War Observer', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT War Observer', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) {
                     $aggressor = UniverseName::firstOrNew(

--- a/src/Notifications/Wars/Discord/AllyJoinedWarAggressorMsg.php
+++ b/src/Notifications/Wars/Discord/AllyJoinedWarAggressorMsg.php
@@ -22,8 +22,11 @@
 
 namespace Seat\Notifications\Notifications\Wars\Discord;
 
+use Illuminate\Support\Collection;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Universe\UniverseName;
+use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
+use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
 use Seat\Notifications\Notifications\AbstractDiscordNotification;
 use Seat\Notifications\Services\Discord\Messages\DiscordEmbed;
 use Seat\Notifications\Services\Discord\Messages\DiscordEmbedField;
@@ -35,7 +38,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Wars\Discord
  */
-class AllyJoinedWarAggressorMsg extends AbstractDiscordNotification
+class AllyJoinedWarAggressorMsg extends AbstractDiscordNotification implements ExposesRequiredUniverseIds
 {
     use NotificationTools;
 
@@ -54,6 +57,22 @@ class AllyJoinedWarAggressorMsg extends AbstractDiscordNotification
         $this->notification = $notification;
     }
 
+    public function middleware(): array
+    {
+        return array_merge(
+            parent::middleware(),
+            [new LoadRequiredUniverseIds]
+        );
+    }
+
+    public function getRequiredUniverseIds(): Collection
+    {
+        return collect([
+            $this->notification->text['declaredByID'] ?? $this->notification->text['aggressorID'] ?? null,
+            $this->notification->text['defenderID'] ?? null,
+        ])->filter()->unique()->values();
+    }
+
     /**
      * @param  DiscordMessage  $message
      * @param  $notifiable
@@ -67,8 +86,9 @@ class AllyJoinedWarAggressorMsg extends AbstractDiscordNotification
                 $embed->author('SeAT War Observer', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) {
+                    $aggressor_id = $this->notification->text['declaredByID'] ?? $this->notification->text['aggressorID'];
                     $aggressor = UniverseName::firstOrNew(
-                        ['entity_id' => $this->notification->text['declaredByID']],
+                        ['entity_id' => $aggressor_id],
                         ['name' => trans('web::seat.unknown')]
                     );
 
@@ -80,8 +100,9 @@ class AllyJoinedWarAggressorMsg extends AbstractDiscordNotification
                 });
 
                 $embed->field(function (DiscordEmbedField $field) {
+                    $defender_id = $this->notification->text['defenderID'] ?? $this->notification->text['againstID'];
                     $defender = UniverseName::firstOrNew(
-                        ['entity_id' => $this->notification->text['defenderID']],
+                        ['entity_id' => $defender_id],
                         ['name' => trans('web::seat.unknown')]
                     );
 

--- a/src/Notifications/Wars/Discord/AllyJoinedWarAllyMsg.php
+++ b/src/Notifications/Wars/Discord/AllyJoinedWarAllyMsg.php
@@ -64,7 +64,7 @@ class AllyJoinedWarAllyMsg extends AbstractDiscordNotification
             ->content('A new member has been enroll in a war! :boom:')
             ->embed(function (DiscordEmbed $embed) {
                 $embed->timestamp($this->notification->timestamp);
-                $embed->author('SeAT War Observer', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT War Observer', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) {
                     $aggressor = UniverseName::firstOrNew(

--- a/src/Notifications/Wars/Discord/AllyJoinedWarAllyMsg.php
+++ b/src/Notifications/Wars/Discord/AllyJoinedWarAllyMsg.php
@@ -22,8 +22,11 @@
 
 namespace Seat\Notifications\Notifications\Wars\Discord;
 
+use Illuminate\Support\Collection;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Universe\UniverseName;
+use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
+use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
 use Seat\Notifications\Notifications\AbstractDiscordNotification;
 use Seat\Notifications\Services\Discord\Messages\DiscordEmbed;
 use Seat\Notifications\Services\Discord\Messages\DiscordEmbedField;
@@ -35,7 +38,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Wars\Discord
  */
-class AllyJoinedWarAllyMsg extends AbstractDiscordNotification
+class AllyJoinedWarAllyMsg extends AbstractDiscordNotification implements ExposesRequiredUniverseIds
 {
     use NotificationTools;
 
@@ -54,6 +57,22 @@ class AllyJoinedWarAllyMsg extends AbstractDiscordNotification
         $this->notification = $notification;
     }
 
+    public function middleware(): array
+    {
+        return array_merge(
+            parent::middleware(),
+            [new LoadRequiredUniverseIds]
+        );
+    }
+
+    public function getRequiredUniverseIds(): Collection
+    {
+        return collect([
+            $this->notification->text['declaredByID'] ?? $this->notification->text['aggressorID'] ?? null,
+            $this->notification->text['defenderID'] ?? null,
+        ])->filter()->unique()->values();
+    }
+
     /**
      * @param  DiscordMessage  $message
      * @param  $notifiable
@@ -67,8 +86,9 @@ class AllyJoinedWarAllyMsg extends AbstractDiscordNotification
                 $embed->author('SeAT War Observer', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) {
+                    $aggressor_id = $this->notification->text['declaredByID'] ?? $this->notification->text['aggressorID'];
                     $aggressor = UniverseName::firstOrNew(
-                        ['entity_id' => $this->notification->text['declaredByID']],
+                        ['entity_id' => $aggressor_id],
                         ['name' => trans('web::seat.unknown')]
                     );
 
@@ -80,8 +100,9 @@ class AllyJoinedWarAllyMsg extends AbstractDiscordNotification
                 });
 
                 $embed->field(function (DiscordEmbedField $field) {
+                    $defender_id = $this->notification->text['defenderID'] ?? $this->notification->text['againstID'];
                     $defender = UniverseName::firstOrNew(
-                        ['entity_id' => $this->notification->text['defenderID']],
+                        ['entity_id' => $defender_id],
                         ['name' => trans('web::seat.unknown')]
                     );
 

--- a/src/Notifications/Wars/Discord/AllyJoinedWarDefenderMsg.php
+++ b/src/Notifications/Wars/Discord/AllyJoinedWarDefenderMsg.php
@@ -64,7 +64,7 @@ class AllyJoinedWarDefenderMsg extends AbstractDiscordNotification
             ->content('A new member has been enroll in a war! :boom:')
             ->embed(function (DiscordEmbed $embed) {
                 $embed->timestamp($this->notification->timestamp);
-                $embed->author('SeAT War Observer', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT War Observer', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) {
                     $aggressor = UniverseName::firstOrNew(

--- a/src/Notifications/Wars/Discord/AllyJoinedWarDefenderMsg.php
+++ b/src/Notifications/Wars/Discord/AllyJoinedWarDefenderMsg.php
@@ -22,8 +22,11 @@
 
 namespace Seat\Notifications\Notifications\Wars\Discord;
 
+use Illuminate\Support\Collection;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Universe\UniverseName;
+use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
+use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
 use Seat\Notifications\Notifications\AbstractDiscordNotification;
 use Seat\Notifications\Services\Discord\Messages\DiscordEmbed;
 use Seat\Notifications\Services\Discord\Messages\DiscordEmbedField;
@@ -35,7 +38,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Wars\Discord
  */
-class AllyJoinedWarDefenderMsg extends AbstractDiscordNotification
+class AllyJoinedWarDefenderMsg extends AbstractDiscordNotification implements ExposesRequiredUniverseIds
 {
     use NotificationTools;
 
@@ -54,6 +57,22 @@ class AllyJoinedWarDefenderMsg extends AbstractDiscordNotification
         $this->notification = $notification;
     }
 
+    public function middleware(): array
+    {
+        return array_merge(
+            parent::middleware(),
+            [new LoadRequiredUniverseIds]
+        );
+    }
+
+    public function getRequiredUniverseIds(): Collection
+    {
+        return collect([
+            $this->notification->text['declaredByID'] ?? $this->notification->text['aggressorID'] ?? null,
+            $this->notification->text['defenderID'] ?? null,
+        ])->filter()->unique()->values();
+    }
+
     /**
      * @param  DiscordMessage  $message
      * @param  $notifiable
@@ -67,8 +86,9 @@ class AllyJoinedWarDefenderMsg extends AbstractDiscordNotification
                 $embed->author('SeAT War Observer', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) {
+                    $aggressor_id = $this->notification->text['declaredByID'] ?? $this->notification->text['aggressorID'];
                     $aggressor = UniverseName::firstOrNew(
-                        ['entity_id' => $this->notification->text['declaredByID']],
+                        ['entity_id' => $aggressor_id],
                         ['name' => trans('web::seat.unknown')]
                     );
 
@@ -80,8 +100,9 @@ class AllyJoinedWarDefenderMsg extends AbstractDiscordNotification
                 });
 
                 $embed->field(function (DiscordEmbedField $field) {
+                    $defender_id = $this->notification->text['defenderID'] ?? $this->notification->text['againstID'];
                     $defender = UniverseName::firstOrNew(
-                        ['entity_id' => $this->notification->text['defenderID']],
+                        ['entity_id' => $defender_id],
                         ['name' => trans('web::seat.unknown')]
                     );
 

--- a/src/Notifications/Wars/Discord/WarDeclaredMsg.php
+++ b/src/Notifications/Wars/Discord/WarDeclaredMsg.php
@@ -67,7 +67,7 @@ class WarDeclaredMsg extends AbstractDiscordNotification
             ->embed(function (DiscordEmbed $embed) {
                 $embed->timestamp($this->notification->timestamp);
                 $embed->color($this->notification->text['hostileState'] ? 13632027 : 16098851);
-                $embed->author('SeAT War Observer', asset('web/img/favico/apple-icon-180x180.png'));
+                $embed->author('SeAT War Observer', asset('web/img/favicon/apple-icon-180x180.png'));
 
                 $embed->field(function (DiscordEmbedField $field) {
                     $aggressor = UniverseName::firstOrNew(

--- a/src/Notifications/Wars/Discord/WarDeclaredMsg.php
+++ b/src/Notifications/Wars/Discord/WarDeclaredMsg.php
@@ -22,8 +22,11 @@
 
 namespace Seat\Notifications\Notifications\Wars\Discord;
 
+use Illuminate\Support\Collection;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Universe\UniverseName;
+use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
+use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
 use Seat\Notifications\Notifications\AbstractDiscordNotification;
 use Seat\Notifications\Services\Discord\Messages\DiscordEmbed;
 use Seat\Notifications\Services\Discord\Messages\DiscordEmbedField;
@@ -35,7 +38,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Wars\Discord
  */
-class WarDeclaredMsg extends AbstractDiscordNotification
+class WarDeclaredMsg extends AbstractDiscordNotification implements ExposesRequiredUniverseIds
 {
     use NotificationTools;
 
@@ -52,6 +55,22 @@ class WarDeclaredMsg extends AbstractDiscordNotification
     public function __construct(CharacterNotification $notification)
     {
         $this->notification = $notification;
+    }
+
+    public function middleware(): array
+    {
+        return array_merge(
+            parent::middleware(),
+            [new LoadRequiredUniverseIds]
+        );
+    }
+
+    public function getRequiredUniverseIds(): Collection
+    {
+        return collect([
+            $this->notification->text['declaredByID'] ?? null,
+            $this->notification->text['againstID'] ?? null,
+        ])->filter()->unique()->values();
     }
 
     /**

--- a/src/Notifications/Wars/Slack/AllWarDeclaredMsg.php
+++ b/src/Notifications/Wars/Slack/AllWarDeclaredMsg.php
@@ -23,8 +23,11 @@
 namespace Seat\Notifications\Notifications\Wars\Slack;
 
 use Illuminate\Notifications\Messages\SlackMessage;
+use Illuminate\Support\Collection;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Universe\UniverseName;
+use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
+use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 
 /**
@@ -32,7 +35,7 @@ use Seat\Notifications\Notifications\AbstractSlackNotification;
  *
  * @package Seat\Notifications\Notifications\Corporations\Slack
  */
-class AllWarDeclaredMsg extends AbstractSlackNotification
+class AllWarDeclaredMsg extends AbstractSlackNotification implements ExposesRequiredUniverseIds
 {
     /**
      * @var \Seat\Eveapi\Models\Character\CharacterNotification
@@ -47,6 +50,22 @@ class AllWarDeclaredMsg extends AbstractSlackNotification
     public function __construct(CharacterNotification $notification)
     {
         $this->notification = $notification;
+    }
+
+    public function middleware(): array
+    {
+        return array_merge(
+            parent::middleware(),
+            [new LoadRequiredUniverseIds]
+        );
+    }
+
+    public function getRequiredUniverseIds(): Collection
+    {
+        return collect([
+            $this->notification->text['declaredByID'] ?? null,
+            $this->notification->text['againstID'] ?? null,
+        ])->filter()->unique()->values();
     }
 
     /**

--- a/src/Notifications/Wars/Slack/AllWarInvalidatedMsg.php
+++ b/src/Notifications/Wars/Slack/AllWarInvalidatedMsg.php
@@ -23,8 +23,11 @@
 namespace Seat\Notifications\Notifications\Wars\Slack;
 
 use Illuminate\Notifications\Messages\SlackMessage;
+use Illuminate\Support\Collection;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Universe\UniverseName;
+use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
+use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 
 /***
@@ -32,7 +35,7 @@ use Seat\Notifications\Notifications\AbstractSlackNotification;
  *
  * @package Seat\Notifications\Notifications\Corporations\Slack
  */
-class AllWarInvalidatedMsg extends AbstractSlackNotification
+class AllWarInvalidatedMsg extends AbstractSlackNotification implements ExposesRequiredUniverseIds
 {
     /**
      * @var \Seat\Eveapi\Models\Character\CharacterNotification
@@ -47,6 +50,22 @@ class AllWarInvalidatedMsg extends AbstractSlackNotification
     public function __construct(CharacterNotification $notification)
     {
         $this->notification = $notification;
+    }
+
+    public function middleware(): array
+    {
+        return array_merge(
+            parent::middleware(),
+            [new LoadRequiredUniverseIds]
+        );
+    }
+
+    public function getRequiredUniverseIds(): Collection
+    {
+        return collect([
+            $this->notification->text['declaredByID'] ?? null,
+            $this->notification->text['againstID'] ?? null,
+        ])->filter()->unique()->values();
     }
 
     /**
@@ -66,7 +85,7 @@ class AllWarInvalidatedMsg extends AbstractSlackNotification
                             ['name' => trans('web::seat.unknown')]
                         );
 
-                        $field->title('Agressor')
+                        $field->title('Aggressor')
                             ->content($entity->name);
                     })
                     ->field(function ($field) {
@@ -75,7 +94,7 @@ class AllWarInvalidatedMsg extends AbstractSlackNotification
                             ['name' => trans('web::seat.unknown')]
                         );
 
-                        $field->title('Victim')
+                        $field->title('Defender')
                             ->content($entity->name);
                     });
             })

--- a/src/Notifications/Wars/Slack/AllyJoinedWarAggressorMsg.php
+++ b/src/Notifications/Wars/Slack/AllyJoinedWarAggressorMsg.php
@@ -23,8 +23,11 @@
 namespace Seat\Notifications\Notifications\Wars\Slack;
 
 use Illuminate\Notifications\Messages\SlackMessage;
+use Illuminate\Support\Collection;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Universe\UniverseName;
+use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
+use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 use Seat\Notifications\Traits\NotificationTools;
 
@@ -33,7 +36,7 @@ use Seat\Notifications\Traits\NotificationTools;
  *
  * @package Seat\Notifications\Notifications\Wars\Slack
  */
-class AllyJoinedWarAggressorMsg extends AbstractSlackNotification
+class AllyJoinedWarAggressorMsg extends AbstractSlackNotification implements ExposesRequiredUniverseIds
 {
     use NotificationTools;
 
@@ -52,6 +55,22 @@ class AllyJoinedWarAggressorMsg extends AbstractSlackNotification
         $this->notification = $notification;
     }
 
+    public function middleware(): array
+    {
+        return array_merge(
+            parent::middleware(),
+            [new LoadRequiredUniverseIds]
+        );
+    }
+
+    public function getRequiredUniverseIds(): Collection
+    {
+        return collect([
+            $this->notification->text['aggressorID'] ?? $this->notification->text['declaredByID'] ?? null,
+            $this->notification->text['defenderID'] ?? $this->notification->text['againstID'] ?? null,
+        ])->filter()->unique()->values();
+    }
+
     /**
      * @param  $notifiable
      * @return \Illuminate\Notifications\Messages\SlackMessage
@@ -65,8 +84,9 @@ class AllyJoinedWarAggressorMsg extends AbstractSlackNotification
                 $attachment
                     ->timestamp($this->mssqlTimestampToDate($this->notification->text['startTime']))
                     ->field(function ($field) {
+                        $aggressor_id = $this->notification->text['aggressorID'] ?? $this->notification->text['declaredByID'];
                         $entity = UniverseName::firstOrNew(
-                            ['entity_id' => $this->notification->text['aggressorID']],
+                            ['entity_id' => $aggressor_id],
                             ['name' => trans('web::seat.unknown')]
                         );
 
@@ -74,8 +94,9 @@ class AllyJoinedWarAggressorMsg extends AbstractSlackNotification
                             ->content($entity->name);
                     })
                     ->field(function ($field) {
+                        $defender_id = $this->notification->text['defenderID'] ?? $this->notification->text['againstID'];
                         $entity = UniverseName::firstOrNew(
-                            ['entity_id' => $this->notification->text['defenderID']],
+                            ['entity_id' => $defender_id],
                             ['name' => trans('web::seat.unknown')]
                         );
 

--- a/src/Notifications/Wars/Slack/AllyJoinedWarAllyMsg.php
+++ b/src/Notifications/Wars/Slack/AllyJoinedWarAllyMsg.php
@@ -23,17 +23,23 @@
 namespace Seat\Notifications\Notifications\Wars\Slack;
 
 use Illuminate\Notifications\Messages\SlackMessage;
+use Illuminate\Support\Collection;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Universe\UniverseName;
+use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
+use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
+use Seat\Notifications\Traits\NotificationTools;
 
 /**
  * Class AllyJoinedWarAllyMsg.
  *
  * @package Seat\Notifications\Notifications\Wars\Slack
  */
-class AllyJoinedWarAllyMsg extends AbstractSlackNotification
+class AllyJoinedWarAllyMsg extends AbstractSlackNotification implements ExposesRequiredUniverseIds
 {
+    use NotificationTools;
+
     /**
      * @var \Seat\Eveapi\Models\Character\CharacterNotification
      */
@@ -49,6 +55,22 @@ class AllyJoinedWarAllyMsg extends AbstractSlackNotification
         $this->notification = $notification;
     }
 
+    public function middleware(): array
+    {
+        return array_merge(
+            parent::middleware(),
+            [new LoadRequiredUniverseIds]
+        );
+    }
+
+    public function getRequiredUniverseIds(): Collection
+    {
+        return collect([
+            $this->notification->text['aggressorID'] ?? $this->notification->text['declaredByID'] ?? null,
+            $this->notification->text['defenderID'] ?? $this->notification->text['againstID'] ?? null,
+        ])->filter()->unique()->values();
+    }
+
     /**
      * @param  $notifiable
      * @return \Illuminate\Notifications\Messages\SlackMessage
@@ -62,8 +84,9 @@ class AllyJoinedWarAllyMsg extends AbstractSlackNotification
                 $attachment
                     ->timestamp($this->mssqlTimestampToDate($this->notification->text['startTime']))
                     ->field(function ($field) {
+                        $aggressor_id = $this->notification->text['aggressorID'] ?? $this->notification->text['declaredByID'];
                         $entity = UniverseName::firstOrNew(
-                            ['entity_id' => $this->notification->text['aggressorID']],
+                            ['entity_id' => $aggressor_id],
                             ['name' => trans('web::seat.unknown')]
                         );
 
@@ -71,8 +94,9 @@ class AllyJoinedWarAllyMsg extends AbstractSlackNotification
                             ->content($entity->name);
                     })
                     ->field(function ($field) {
+                        $defender_id = $this->notification->text['defenderID'] ?? $this->notification->text['againstID'];
                         $entity = UniverseName::firstOrNew(
-                            ['entity_id' => $this->notification->text['defenderID']],
+                            ['entity_id' => $defender_id],
                             ['name' => trans('web::seat.unknown')]
                         );
 

--- a/src/Notifications/Wars/Slack/AllyJoinedWarDefenderMsg.php
+++ b/src/Notifications/Wars/Slack/AllyJoinedWarDefenderMsg.php
@@ -23,17 +23,23 @@
 namespace Seat\Notifications\Notifications\Wars\Slack;
 
 use Illuminate\Notifications\Messages\SlackMessage;
+use Illuminate\Support\Collection;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Universe\UniverseName;
+use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
+use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
+use Seat\Notifications\Traits\NotificationTools;
 
 /**
  * Class AllyJoinedWarDefenderMsg.
  *
  * @package Seat\Notifications\Notifications\Wars\Slack
  */
-class AllyJoinedWarDefenderMsg extends AbstractSlackNotification
+class AllyJoinedWarDefenderMsg extends AbstractSlackNotification implements ExposesRequiredUniverseIds
 {
+    use NotificationTools;
+
     /**
      * @var \Seat\Eveapi\Models\Character\CharacterNotification
      */
@@ -49,6 +55,22 @@ class AllyJoinedWarDefenderMsg extends AbstractSlackNotification
         $this->notification = $notification;
     }
 
+    public function middleware(): array
+    {
+        return array_merge(
+            parent::middleware(),
+            [new LoadRequiredUniverseIds]
+        );
+    }
+
+    public function getRequiredUniverseIds(): Collection
+    {
+        return collect([
+            $this->notification->text['aggressorID'] ?? $this->notification->text['declaredByID'] ?? null,
+            $this->notification->text['defenderID'] ?? $this->notification->text['againstID'] ?? null,
+        ])->filter()->unique()->values();
+    }
+
     /**
      * @param  $notifiable
      * @return \Illuminate\Notifications\Messages\SlackMessage
@@ -62,8 +84,9 @@ class AllyJoinedWarDefenderMsg extends AbstractSlackNotification
                 $attachment
                     ->timestamp($this->mssqlTimestampToDate($this->notification->text['startTime']))
                     ->field(function ($field) {
+                        $aggressor_id = $this->notification->text['aggressorID'] ?? $this->notification->text['declaredByID'];
                         $entity = UniverseName::firstOrNew(
-                            ['entity_id' => $this->notification->text['aggressorID']],
+                            ['entity_id' => $aggressor_id],
                             ['name' => trans('web::seat.unknown')]
                         );
 
@@ -71,8 +94,9 @@ class AllyJoinedWarDefenderMsg extends AbstractSlackNotification
                             ->content($entity->name);
                     })
                     ->field(function ($field) {
+                        $defender_id = $this->notification->text['defenderID'] ?? $this->notification->text['againstID'];
                         $entity = UniverseName::firstOrNew(
-                            ['entity_id' => $this->notification->text['defenderID']],
+                            ['entity_id' => $defender_id],
                             ['name' => trans('web::seat.unknown')]
                         );
 

--- a/src/Notifications/Wars/Slack/WarDeclaredMsg.php
+++ b/src/Notifications/Wars/Slack/WarDeclaredMsg.php
@@ -23,8 +23,11 @@
 namespace Seat\Notifications\Notifications\Wars\Slack;
 
 use Illuminate\Notifications\Messages\SlackMessage;
+use Illuminate\Support\Collection;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Universe\UniverseName;
+use Seat\Notifications\Contracts\ExposesRequiredUniverseIds;
+use Seat\Notifications\Jobs\Middleware\LoadRequiredUniverseIds;
 use Seat\Notifications\Notifications\AbstractSlackNotification;
 
 /**
@@ -32,7 +35,7 @@ use Seat\Notifications\Notifications\AbstractSlackNotification;
  *
  * @package Seat\Notifications\Notifications\Corporations\Slack
  */
-class WarDeclaredMsg extends AbstractSlackNotification
+class WarDeclaredMsg extends AbstractSlackNotification implements ExposesRequiredUniverseIds
 {
     /**
      * @var \Seat\Eveapi\Models\Character\CharacterNotification
@@ -47,6 +50,22 @@ class WarDeclaredMsg extends AbstractSlackNotification
     public function __construct(CharacterNotification $notification)
     {
         $this->notification = $notification;
+    }
+
+    public function middleware(): array
+    {
+        return array_merge(
+            parent::middleware(),
+            [new LoadRequiredUniverseIds]
+        );
+    }
+
+    public function getRequiredUniverseIds(): Collection
+    {
+        return collect([
+            $this->notification->text['declaredByID'] ?? null,
+            $this->notification->text['againstID'] ?? null,
+        ])->filter()->unique()->values();
     }
 
     /**

--- a/src/Services/Discord/Messages/DiscordMessage.php
+++ b/src/Services/Discord/Messages/DiscordMessage.php
@@ -189,6 +189,12 @@ class DiscordMessage
      */
     public function content(string $content): DiscordMessage
     {
+        if (empty($this->content)) {
+            $this->content = $content;
+
+            return $this;
+        }
+
         $this->content = "$this->content\n$content";
 
         return $this;

--- a/src/Traits/NotificationDispatchTool.php
+++ b/src/Traits/NotificationDispatchTool.php
@@ -41,7 +41,7 @@ trait NotificationDispatchTool
                         'channel' => $channel->type,
                         'route' => $route,
                         'mentions' => $group->mentions->filter(function ($mention) use ($channel) {
-                            return $mention->getType()->type = $channel->type;
+                            return $mention->getType()->type === $channel->type;
                         }),
                     ];
                 });

--- a/src/Traits/NotificationTools.php
+++ b/src/Traits/NotificationTools.php
@@ -33,6 +33,56 @@ use Seat\Services\Image\Eve;
 trait NotificationTools
 {
     /**
+     * Convert an EVE notification duration value stored in 100ns ticks into a readable string.
+     *
+     * @param  int|string  $duration
+     * @return string
+     */
+    public function eveDurationToString(int|string $duration): string
+    {
+        $seconds = max(0, (int) floor(((int) $duration) / 10000000));
+
+        if ($seconds === 0)
+            return '0 seconds';
+
+        $parts = [];
+        $days = intdiv($seconds, 86400);
+        $seconds %= 86400;
+        $hours = intdiv($seconds, 3600);
+        $seconds %= 3600;
+        $minutes = intdiv($seconds, 60);
+        $seconds %= 60;
+
+        if ($days > 0)
+            $parts[] = sprintf('%d day%s', $days, $days === 1 ? '' : 's');
+
+        if ($hours > 0)
+            $parts[] = sprintf('%d hour%s', $hours, $hours === 1 ? '' : 's');
+
+        if ($minutes > 0)
+            $parts[] = sprintf('%d minute%s', $minutes, $minutes === 1 ? '' : 's');
+
+        if ($seconds > 0 && count($parts) < 2)
+            $parts[] = sprintf('%d second%s', $seconds, $seconds === 1 ? '' : 's');
+
+        return implode(' ', array_slice($parts, 0, 3));
+    }
+
+    /**
+     * Convert an EVE notification duration value stored in 100ns ticks into an absolute UTC datetime string.
+     *
+     * @param  int|string  $duration
+     * @param  mixed  $reference
+     * @return string
+     */
+    public function eveDurationToDateTimeString(int|string $duration, $reference): string
+    {
+        $seconds = max(0, (int) floor(((int) $duration) / 10000000));
+
+        return carbon($reference)->copy()->setTimezone('UTC')->addSeconds($seconds)->format('Y.m.d H:i:s');
+    }
+
+    /**
      * Build a link to Eve Type.
      *
      * @param  int  $type_id

--- a/src/resources/lang/en/alerts.php
+++ b/src/resources/lang/en/alerts.php
@@ -48,6 +48,7 @@ return [
     'moon_mining_extraction_finished' => 'MM Finished Extractions',
     'moon_mining_extraction_started' => 'MM Started Extractions',
     'orbital_attacked' => 'Attacked Customs Office',
+    'orbital_reinforced' => 'Reinforced Customs Office',
     'ownership_transferred' => 'Transferred Ownership',
     'raffle_created' => 'Created Raffle',
     'raffle_expired' => 'Expired Raffle',


### PR DESCRIPTION
- Fixed Skyhook notifications so they actually work.  They were completely inoperable before.
- Fixed bug where StructureUnderAttack would never show the alliance of the attacker
- Fixed bug where mention group would be used in the wrong integration due to a assignment/comparison typo
- Fixed bug where notifications would sometimes be prefixed with a blank new line for no reason.